### PR TITLE
refactor: 카카오 로그인 콜백 처리 로직을 전용 훅으로 분리

### DIFF
--- a/app/login/kakao/page.tsx
+++ b/app/login/kakao/page.tsx
@@ -1,52 +1,13 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
-import { Suspense, useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Suspense } from 'react';
 
-import { kakaoLogin } from '@/features/auth/kakao/fetchers';
-import { completeLoginSession } from '@/features/auth/lib/complete-login';
-import { consumeLoginReturnPath } from '@/features/auth/lib/login-return-path';
-import { ROUTES } from '@/shared/constants/routes';
+import { useKakaoCallback } from '@/features/auth/kakao/use-kakao-callback';
 
 const KakaoCallbackContent = () => {
-  const router = useRouter();
   const searchParams = useSearchParams();
-  const code = searchParams.get('code');
-  const error = searchParams.get('error');
-  const didRun = useRef(false);
-  const [message, setMessage] = useState('카카오 로그인 중...');
-
-  useEffect(() => {
-    if (didRun.current) {
-      return;
-    }
-
-    didRun.current = true;
-
-    if (error || !code) {
-      router.replace(ROUTES.HOME);
-      return;
-    }
-
-    const handleLogin = async () => {
-      try {
-        const login = await kakaoLogin(code);
-        const { needsOnboarding } = await completeLoginSession(login);
-
-        if (needsOnboarding) {
-          router.replace(ROUTES.SIGNUP);
-          return;
-        }
-
-        router.replace(consumeLoginReturnPath());
-      } catch {
-        setMessage('로그인에 실패했습니다. 메인으로 이동합니다.');
-        router.replace(ROUTES.HOME);
-      }
-    };
-
-    void handleLogin();
-  }, [code, error, router]);
+  const { message } = useKakaoCallback(searchParams.get('code'), searchParams.get('error'));
 
   return (
     <div className="flex min-h-screen items-center justify-center">

--- a/features/auth/kakao/use-kakao-callback.ts
+++ b/features/auth/kakao/use-kakao-callback.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+
+import { ROUTES } from '@/shared/constants/routes';
+
+import { kakaoLogin } from './fetchers';
+import { completeLoginSession } from '../lib/complete-login';
+import { consumeLoginReturnPath } from '../lib/login-return-path';
+
+export const useKakaoCallback = (code: string | null, error: string | null) => {
+  const router = useRouter();
+  const didRun = useRef(false);
+  const [message, setMessage] = useState('카카오 로그인 중...');
+
+  useEffect(() => {
+    if (didRun.current) {
+      return;
+    }
+    didRun.current = true;
+
+    if (error || !code) {
+      router.replace(ROUTES.HOME);
+      return;
+    }
+
+    const handleLogin = async () => {
+      try {
+        const login = await kakaoLogin(code);
+        const { needsOnboarding } = await completeLoginSession(login);
+        router.replace(needsOnboarding ? ROUTES.SIGNUP : consumeLoginReturnPath());
+      } catch {
+        setMessage('로그인에 실패했습니다. 메인으로 이동합니다.');
+        router.replace(ROUTES.HOME);
+      }
+    };
+
+    handleLogin();
+  }, [code, error, router]);
+
+  return { message };
+};


### PR DESCRIPTION
# 📝 개요

기존 카카오 로그인 콜백 처리가 UI와 함께 구성되어 있어, 페이지 컴포넌트의 책임이 커지고 인증 흐름의 성공/실패 분기를 파악하기 어려웠습니다.

콜백 처리 로직을 `useKakaoCallback` 훅으로 분리해 페이지는 로딩 메시지 렌더링에 집중하고, 로그인 API 호출, 세션 저장, 온보딩 분기, 리다이렉트 처리는 훅에서 관리하도록 개선했습니다.

## 🔗 관련 이슈

- Closes #135 

## 🛠️ 변경 사항 (Checklist)

- [ ] ✨ Feature: 새로운 기능 추가
- [ ] 🚀 Enhancement: 기존 기능 개선/성능 향상
- [ ] 🐞 Bug: 버그 수정
- [x] ♻️ Refactor: 코드 구조 개선 (기능 변화 없음)
- [ ] 🏗️ Chore: 빌드/패키지 설정/단순 잡일
- [ ] 🎨 Design: UI/UX 스타일 수정
- [ ] 📚 Documentation: 문서 수정

## ✅ 아래 내용을 한 번 더 점검해 주세요

### 1. 의도와 가독성 (Naming & Readability)

- [x] **의도 중심 네이밍**: 변수명에서 '역할'이, 함수명에서 '행위+대상'이 명확히 드러나나요?
- [x] **선언적 코드**: '어떻게'가 아닌 '무엇을' 하는지 코드만 보고도 알 수 있나요? (복잡한 로직은 내부 메서드로 숨겼나요?)
- [x] **주석**: 코드만으로 설명이 어려운 '특정 로직'에만 주석을 달았나요?

### 2. 타입과 논리 (Type Safety & Logic)

- [x] **타입 안전성**: `any` 사용을 지양하고, 모든 함수의 반환 타입을 명시했나요?
- [x] **엣지 케이스**: 데이터가 없거나(`null/undefined`), 에러가 발생할 경우를 처리했나요?
- [x] **하드코딩 방지**: API 주소나 설정값들이 환경 변수나 상수로 분리되었나요?

### 3. 코드 다이어트 (Clean-up)

- [x] **찌꺼기 제거**: 디버깅용 `console.log`나 사용하지 않는 `import`를 모두 지웠나요?
- [x] **불필요한 코드**: "나중에 쓰겠지" 하고 남겨둔 죽은 코드(Dead Code)는 없나요?
- [x] **Linter**: 린트 에러나 워닝이 남아있지 않나요?

### 4. 지속 가능성 (Sustainability)

- [ ] **테스트**: 수동으로든 코드로든 정상 작동을 확인했나요? (특히 기존 기능이 망가지지 않았나요?)
- [ ] **문서화**: 새로운 환경 변수나 라이브러리가 추가되어 `README` 업데이트가 필요한가요?

---

## 💭 회고 (Optional)
