### PR TITLE
feat: 초대 수락 로직 및 invalidate 범위 세팅

### DIFF
--- a/app/projects/invite/page.tsx
+++ b/app/projects/invite/page.tsx
@@ -1,0 +1,24 @@
+import { Suspense } from 'react';
+
+import { ProjectInvitePageContent } from '@/features/project/components/project-invite-page-content';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Sossbar - 프로젝트 초대',
+  description: '프로젝트 팀에 참여하고 동료와 후기를 나눠 보세요',
+};
+
+const ProjectInviteFallback = () => (
+  <div className="flex min-h-[240px] items-center justify-center">
+    <p className="text-body-base text-text-subtle">화면을 불러오는 중…</p>
+  </div>
+);
+
+const ProjectInvitePage = () => (
+  <Suspense fallback={<ProjectInviteFallback />}>
+    <ProjectInvitePageContent />
+  </Suspense>
+);
+
+export default ProjectInvitePage;

--- a/features/project/api/mutations.ts
+++ b/features/project/api/mutations.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type { CreateProjectPayload, UpdateProjectPayload } from '@/features/project/types';
+import { useSessionUser } from '@/shared/lib/session-user';
 
 import {
   confirmProjectMembers,
@@ -11,65 +12,85 @@ import {
   updateProject,
 } from './fetchers';
 import { projectKeys } from './query-keys';
+import { invalidateProjectListQueries } from '../lib/invalidate-project-queries';
 
 export const useCreateProject = () => {
   const queryClient = useQueryClient();
+  const sessionUser = useSessionUser();
+
   return useMutation({
     mutationFn: (payload: CreateProjectPayload) => createProject(payload),
     onSuccess: (data) => {
       queryClient.setQueryData(projectKeys.detail(data.projectId), data);
-      queryClient.invalidateQueries({ queryKey: projectKeys.list() });
+      invalidateProjectListQueries(queryClient, sessionUser?.userId);
     },
   });
 };
 
 export const useUpdateProject = (projectId: number) => {
   const queryClient = useQueryClient();
+  const sessionUser = useSessionUser();
+
   return useMutation({
     mutationFn: (payload: UpdateProjectPayload) => updateProject(projectId, payload),
     onSuccess: (data) => {
       queryClient.setQueryData(projectKeys.detail(data.projectId), data);
+      invalidateProjectListQueries(queryClient, sessionUser?.userId);
     },
   });
 };
 
 export const useDeleteProject = () => {
   const queryClient = useQueryClient();
+  const sessionUser = useSessionUser();
+
   return useMutation({
     mutationFn: (projectId: number) => deleteProject(projectId),
     onSuccess: (_data, projectId) => {
       queryClient.removeQueries({ queryKey: projectKeys.detail(projectId) });
+      invalidateProjectListQueries(queryClient, sessionUser?.userId);
     },
   });
 };
 
 export const useInviteProjectMember = (projectId: number) => {
   const queryClient = useQueryClient();
+  const sessionUser = useSessionUser();
+
   return useMutation({
     mutationFn: () => inviteProjectMember(projectId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: projectKeys.detail(projectId) });
+      void queryClient.invalidateQueries({ queryKey: projectKeys.detail(projectId) });
+      invalidateProjectListQueries(queryClient, sessionUser?.userId);
     },
   });
 };
 
 export const useDeleteProjectMember = (projectId: number) => {
   const queryClient = useQueryClient();
+  const sessionUser = useSessionUser();
+
   return useMutation({
     mutationFn: (userId: number) => deleteProjectMember(projectId, userId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: projectKeys.detail(projectId) });
+    onSuccess: (_data, removedUserId) => {
+      void queryClient.invalidateQueries({ queryKey: projectKeys.detail(projectId) });
+      invalidateProjectListQueries(queryClient, sessionUser?.userId);
+      if (removedUserId > 0) {
+        void queryClient.invalidateQueries({ queryKey: projectKeys.byUser(removedUserId) });
+      }
     },
   });
 };
 
 export const useConfirmProjectMembers = (projectId: number) => {
   const queryClient = useQueryClient();
+  const sessionUser = useSessionUser();
+
   return useMutation({
     mutationFn: () => confirmProjectMembers(projectId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: projectKeys.detail(projectId) });
-      queryClient.invalidateQueries({ queryKey: projectKeys.list() });
+      void queryClient.invalidateQueries({ queryKey: projectKeys.detail(projectId) });
+      invalidateProjectListQueries(queryClient, sessionUser?.userId);
     },
   });
 };

--- a/features/project/components/project-card.tsx
+++ b/features/project/components/project-card.tsx
@@ -108,13 +108,6 @@ export const ProjectCard = ({ project }: ProjectCardProps) => {
         />
         <ProjectCardTitle projectName={project.projectName} host={project.host} />
         <ProjectCardActions projectId={project.projectId} isLeader={isLeader} projectStatus={project.projectStatus} />
-        <ProjectMemberList projectId={project.projectId} members={project.members} />
-        <ProjectCardActions
-          projectId={project.projectId}
-          isLeader={isLeader}
-          projectStatus={project.projectStatus}
-          projectLink={project.projectLink}
-        />
         <ProjectMemberList projectId={project.projectId} members={project.members} isLeader={isLeader} />
       </div>
 

--- a/features/project/components/project-card.tsx
+++ b/features/project/components/project-card.tsx
@@ -65,7 +65,6 @@ interface ProjectCardActionsProps {
   projectId: number;
   isLeader: boolean;
   projectStatus: ProjectCardItem['projectStatus'];
-  projectLink: string;
 }
 
 interface ProjectMemberListProps {
@@ -88,12 +87,7 @@ export const ProjectCard = ({ project }: ProjectCardProps) => {
           startDate={project.startDate}
         />
         <ProjectCardTitle projectName={project.projectName} host={project.host} />
-        <ProjectCardActions
-          projectId={project.projectId}
-          isLeader={isLeader}
-          projectStatus={project.projectStatus}
-          projectLink={project.projectLink}
-        />
+        <ProjectCardActions projectId={project.projectId} isLeader={isLeader} projectStatus={project.projectStatus} />
         <ProjectMemberList projectId={project.projectId} members={project.members} />
       </div>
     </article>
@@ -160,7 +154,7 @@ const ProjectCardTitle = ({ host, projectName }: ProjectCardTitleProps) => {
   );
 };
 
-const ProjectCardActions = ({ projectId, isLeader, projectStatus, projectLink }: ProjectCardActionsProps) => {
+const ProjectCardActions = ({ projectId, isLeader, projectStatus }: ProjectCardActionsProps) => {
   const {
     open: isInviteTooltipOpen,
     message: inviteTooltipMessage,
@@ -182,11 +176,7 @@ const ProjectCardActions = ({ projectId, isLeader, projectStatus, projectLink }:
   }, [confirmTeam]);
 
   const handleCopyInviteLink = async () => {
-    if (!projectLink.trim()) {
-      return;
-    }
-
-    await copyLink(buildProjectInviteUrl(projectLink));
+    await copyLink(buildProjectInviteUrl(projectId));
   };
 
   if (!isLeader) {

--- a/features/project/components/project-invite-page-content.tsx
+++ b/features/project/components/project-invite-page-content.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useMemo, useState } from 'react';
+
+import { saveLoginReturnPath } from '@/features/auth/lib/login-return-path';
+import { useInviteProjectMember } from '@/features/project/api/mutations';
+import { useProject } from '@/features/project/api/queries';
+import { parseProjectInviteId } from '@/features/project/lib/parse-project-invite-id';
+import { Button } from '@/shared/components/button';
+import { ConfirmationDialog } from '@/shared/components/dialog/confirmation-dialog';
+import { PageContainer } from '@/shared/components/page-container';
+import { useLoginModal } from '@/shared/hooks/use-login-modal';
+import { ApiError } from '@/shared/lib/api';
+import { useSessionUser } from '@/shared/lib/session-user';
+
+const DEFAULT_PROJECT_IMAGE = '/default.png';
+
+const InvalidInviteMessage = () => (
+  <PageContainer className="py-20">
+    <h1 className="text-heading-base text-text-basic font-bold">유효하지 않은 링크입니다</h1>
+    <p className="text-body-base text-text-subtle mt-3">
+      이미 종료되었거나 유효하지 않은 링크입니다. 프로젝트 방장에게 새 초대 링크를 요청해 주세요.
+    </p>
+    <Button asChild variant="primary" size="medium" className="mt-8">
+      <Link href="/projects">프로젝트 목록으로</Link>
+    </Button>
+  </PageContainer>
+);
+
+export const ProjectInvitePageContent = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const projectId = useMemo(() => parseProjectInviteId(searchParams.get('projectId')), [searchParams]);
+  const sessionUser = useSessionUser();
+  const { openLoginModal } = useLoginModal();
+
+  const [joinDialogOpen, setJoinDialogOpen] = useState(false);
+  const [joinError, setJoinError] = useState<string | null>(null);
+
+  const hasSession = sessionUser != null && sessionUser.userId > 0;
+  const { data: project, isPending, isError, error } = useProject(projectId ?? 0, hasSession && projectId != null);
+  const { mutateAsync: joinProject, isPending: isJoining } = useInviteProjectMember(projectId ?? 0);
+
+  const isAlreadyMember = useMemo(() => {
+    if (!project || !sessionUser) {
+      return false;
+    }
+    return project.members.some((member) => member.userId === sessionUser.userId);
+  }, [project, sessionUser]);
+
+  const handleLogin = () => {
+    saveLoginReturnPath();
+    openLoginModal();
+  };
+
+  const handleJoin = useCallback(async () => {
+    if (projectId == null) {
+      return;
+    }
+    setJoinError(null);
+    try {
+      await joinProject();
+      setJoinDialogOpen(false);
+      router.push('/projects');
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        setJoinError('이미 참여 중인 프로젝트입니다.');
+        return;
+      }
+      setJoinError('프로젝트 참여에 실패했습니다. 다시 시도해 주세요.');
+    }
+  }, [joinProject, projectId, router]);
+
+  if (projectId == null) {
+    return <InvalidInviteMessage />;
+  }
+
+  if (!hasSession) {
+    return (
+      <PageContainer className="py-20">
+        <h1 className="text-heading-base text-text-basic font-bold">프로젝트 초대</h1>
+        <p className="text-body-base text-text-subtle mt-3">참여하려면 먼저 로그인해 주세요.</p>
+        <div className="mt-8 flex gap-2">
+          <Button type="button" variant="primary" size="medium" onClick={handleLogin}>
+            로그인하기
+          </Button>
+          <Button asChild variant="tertiary" size="medium">
+            <Link href="/">홈으로</Link>
+          </Button>
+        </div>
+      </PageContainer>
+    );
+  }
+
+  if (isPending) {
+    return (
+      <PageContainer className="py-20">
+        <p className="text-body-base text-text-subtle">프로젝트 정보를 불러오는 중…</p>
+      </PageContainer>
+    );
+  }
+
+  if (isError || !project) {
+    const isNotFound = error instanceof ApiError && error.status === 404;
+    if (isNotFound) {
+      return <InvalidInviteMessage />;
+    }
+    return (
+      <PageContainer className="py-20">
+        <p className="text-body-base text-text-error">프로젝트 정보를 불러오지 못했습니다.</p>
+        <Button type="button" variant="tertiary" size="medium" className="mt-6" onClick={() => router.refresh()}>
+          다시 시도
+        </Button>
+      </PageContainer>
+    );
+  }
+
+  if (isAlreadyMember) {
+    return (
+      <PageContainer className="py-20">
+        <h1 className="text-heading-base text-text-basic font-bold">이미 참여 중입니다</h1>
+        <p className="text-body-base text-text-subtle mt-3">
+          <span className="text-text-basic font-medium">{project.projectName}</span> 프로젝트 팀원으로 등록되어
+          있습니다.
+        </p>
+        <Button asChild variant="primary" size="medium" className="mt-8">
+          <Link href="/projects">프로젝트 목록으로</Link>
+        </Button>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <PageContainer className="py-20">
+      <div className="flex max-w-lg flex-col gap-6">
+        <div className="relative aspect-4/3 w-full max-w-sm overflow-hidden rounded-2xl">
+          <Image
+            src={project.projectImage ?? DEFAULT_PROJECT_IMAGE}
+            alt={`${project.projectName} 이미지`}
+            fill
+            className="object-cover"
+            sizes="400px"
+          />
+        </div>
+        <div>
+          <h1 className="text-heading-base text-text-basic font-bold">{project.projectName}</h1>
+          <p className="text-body-base text-text-subtle mt-2">{project.host}</p>
+        </div>
+        <p className="text-body-base text-text-subtle">
+          <span className="text-text-basic font-medium">{project.projectName}</span> 프로젝트 후기 작성에
+          참여하시겠습니까?
+        </p>
+        <div className="flex gap-2">
+          <Button type="button" variant="primary" size="medium" onClick={() => setJoinDialogOpen(true)}>
+            참여하기
+          </Button>
+          <Button asChild variant="tertiary" size="medium">
+            <Link href="/projects">취소</Link>
+          </Button>
+        </div>
+      </div>
+
+      <ConfirmationDialog
+        open={joinDialogOpen}
+        title={`${project.projectName}에 참여할까요?`}
+        description="참여하면 팀원 목록에 추가되며, 팀 확정 후 동료에게 후기를 작성할 수 있습니다."
+        confirmText="참여하기"
+        cancelText="취소"
+        onOpenChange={(open) => {
+          if (!open) {
+            setJoinError(null);
+          }
+          setJoinDialogOpen(open);
+        }}
+        onConfirm={handleJoin}
+        isConfirming={isJoining}
+        errorMessage={joinError ?? undefined}
+      />
+    </PageContainer>
+  );
+};

--- a/features/project/components/project-invite-page-content.tsx
+++ b/features/project/components/project-invite-page-content.tsx
@@ -41,7 +41,13 @@ export const ProjectInvitePageContent = () => {
   const [joinError, setJoinError] = useState<string | null>(null);
 
   const hasSession = sessionUser != null && sessionUser.userId > 0;
-  const { data: project, isPending, isError, error } = useProject(projectId ?? 0, hasSession && projectId != null);
+  const {
+    data: project,
+    isPending,
+    isError,
+    error,
+    refetch,
+  } = useProject(projectId ?? 0, hasSession && projectId != null);
   const { mutateAsync: joinProject, isPending: isJoining } = useInviteProjectMember(projectId ?? 0);
 
   const isAlreadyMember = useMemo(() => {
@@ -111,7 +117,7 @@ export const ProjectInvitePageContent = () => {
     return (
       <PageContainer className="py-20">
         <p className="text-body-base text-text-error">프로젝트 정보를 불러오지 못했습니다.</p>
-        <Button type="button" variant="tertiary" size="medium" className="mt-6" onClick={() => router.refresh()}>
+        <Button type="button" variant="tertiary" size="medium" className="mt-6" onClick={() => void refetch()}>
           다시 시도
         </Button>
       </PageContainer>

--- a/features/project/lib/build-project-invite-url.ts
+++ b/features/project/lib/build-project-invite-url.ts
@@ -16,9 +16,9 @@ const getSiteOrigin = (): string => {
   return '';
 };
 
-export const buildProjectInviteUrl = (projectLink: string): string => {
-  const token = projectLink.trim();
-  const path = `/projects/invite/${encodeURIComponent(token)}`;
+/** 초대 링크 — BE join API(`projectId`)와 맞춘 쿼리 URL */
+export const buildProjectInviteUrl = (projectId: number): string => {
+  const path = `/projects/invite?projectId=${projectId}`;
   const origin = getSiteOrigin();
 
   return origin ? `${origin}${path}` : path;

--- a/features/project/lib/invalidate-project-queries.ts
+++ b/features/project/lib/invalidate-project-queries.ts
@@ -1,0 +1,12 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+import { projectKeys } from '../api/query-keys';
+
+/** 프로젝트 목록·프로필 탭 등 목록성 쿼리 갱신 */
+export const invalidateProjectListQueries = (queryClient: QueryClient, userId?: number) => {
+  void queryClient.invalidateQueries({ queryKey: projectKeys.list() });
+
+  if (userId != null && userId > 0) {
+    void queryClient.invalidateQueries({ queryKey: projectKeys.byUser(userId) });
+  }
+};

--- a/features/project/lib/parse-project-invite-id.ts
+++ b/features/project/lib/parse-project-invite-id.ts
@@ -1,0 +1,8 @@
+export const parseProjectInviteId = (raw: string | null): number | null => {
+  if (raw == null || raw.trim() === '') {
+    return null;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+};


### PR DESCRIPTION
# 📝 개요
초대 링크를 projectId 기반 쿼리 URL로 통일하고, /projects/invite 페이지에서 로그인 게이트/참여 확인/참여 처리까지 연결했습니다.
또한 프로젝트 관련 mutation 성공 시 list()뿐 아니라 byUser(userId)까지 함께 invalidate 하도록 정리해 프로필 프로젝트 탭 갱신 누락을 줄였습니다.
## 🔗 관련 이슈

- Closes #151 

## 🛠️ 변경 사항 (Checklist)

- [x] ✨ Feature: 새로운 기능 추가
- [x] 🚀 Enhancement: 기존 기능 개선/성능 향상
- [x] 🐞 Bug: 버그 수정
- [ ] ♻️ Refactor: 코드 구조 개선 (기능 변화 없음)
- [ ] 🏗️ Chore: 빌드/패키지 설정/단순 잡일
- [ ] 🎨 Design: UI/UX 스타일 수정
- [ ] 📚 Documentation: 문서 수정

## ✅ 아래 내용을 한 번 더 점검해 주세요

### 1. 의도와 가독성 (Naming & Readability)

- [ ] **의도 중심 네이밍**: 변수명에서 '역할'이, 함수명에서 '행위+대상'이 명확히 드러나나요?
- [ ] **선언적 코드**: '어떻게'가 아닌 '무엇을' 하는지 코드만 보고도 알 수 있나요? (복잡한 로직은 내부 메서드로 숨겼나요?)
- [ ] **주석**: 코드만으로 설명이 어려운 '특정 로직'에만 주석을 달았나요?

### 2. 타입과 논리 (Type Safety & Logic)

- [ ] **타입 안전성**: `any` 사용을 지양하고, 모든 함수의 반환 타입을 명시했나요?
- [ ] **엣지 케이스**: 데이터가 없거나(`null/undefined`), 에러가 발생할 경우를 처리했나요?
- [ ] **하드코딩 방지**: API 주소나 설정값들이 환경 변수나 상수로 분리되었나요?

### 3. 코드 다이어트 (Clean-up)

- [ ] **찌꺼기 제거**: 디버깅용 `console.log`나 사용하지 않는 `import`를 모두 지웠나요?
- [ ] **불필요한 코드**: "나중에 쓰겠지" 하고 남겨둔 죽은 코드(Dead Code)는 없나요?
- [ ] **Linter**: 린트 에러나 워닝이 남아있지 않나요?

### 4. 지속 가능성 (Sustainability)

- [ ] **테스트**: 수동으로든 코드로든 정상 작동을 확인했나요? (특히 기존 기능이 망가지지 않았나요?)
- [ ] **문서화**: 새로운 환경 변수나 라이브러리가 추가되어 `README` 업데이트가 필요한가요?

---

## 💭 회고 (Optional)
초대 링크 규격을 BE의 join API(projectId)와 맞추면서, 기존에 분산되던 캐시 갱신 정책도 함께 정리해 추후 프로젝트 관련 화면(목록/프로필 탭) 일관성이 좋아졌습니다.
다만 기존에 공유된 projectLink 기반 링크는 호환되지 않으므로, 운영 전환 시점에 새 링크 재공유 안내가 필요합니다.
(+ feat: form-data 응답 매핑 및 방장 액션 ui 연결 PR을 먼저 머지하고 지금 브랜치를 머지하는 순서로 진행해주세요)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로젝트 초대 페이지 및 초대 확인 다이얼로그가 추가되었습니다.
  * 초대 수락 시 간편 참여 흐름(참여하기 버튼 → 확인 → 프로젝트 목록으로 이동)이 제공됩니다.

* **개선 사항**
  * 초대 페이지 로딩/오류 상태 표시 개선(로딩, 404/무효 링크, 재시도, 충돌 메시지).
  * 로그인하지 않은 사용자 대상 명확한 로그인 안내 및 복귀 흐름 추가.
  * 초대 링크/무효화 처리 개선으로 목록 갱신 동작이 더 정확해졌습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JECT-Study/Sossbar-4th-Client/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->