### PR TITLE
fix: 탈퇴 후 재가입 시 동의 절차 없이 자동 로그인되는 보안 이슈 수정

### DIFF
--- a/features/auth/lib/complete-login.ts
+++ b/features/auth/lib/complete-login.ts
@@ -15,9 +15,11 @@ export const completeLoginSession = async (login: LoginInfoResDto): Promise<Comp
   setAuthToken({ accessToken: login.accessToken, userId: login.userId });
 
   const profile = await getMyProfile();
-  setSessionUser(mapProfileToSessionUser(profile));
-
   const needsOnboarding = !profile.username?.trim();
+
+  if (!needsOnboarding) {
+    setSessionUser(mapProfileToSessionUser(profile));
+  }
 
   return { profile, needsOnboarding };
 };

--- a/features/auth/signup/components/signup-form.tsx
+++ b/features/auth/signup/components/signup-form.tsx
@@ -84,6 +84,7 @@ export const SignupForm = () => {
         placeholder="내용을 입력해 주세요. (기본상태)"
         maxLength={BIO_MAX_LENGTH}
         errorMessage={errors.bio?.message}
+        required
         className="mt-10"
         {...register('bio')}
       />

--- a/shared/providers/auth-bootstrap.tsx
+++ b/shared/providers/auth-bootstrap.tsx
@@ -1,18 +1,15 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 
 import { getMyProfile } from '@/features/auth/fetchers';
 import { mapProfileToSessionUser } from '@/features/auth/lib/map-profile-to-session';
-import { ROUTES } from '@/shared/constants/routes';
 import { ApiError } from '@/shared/lib/api';
 import { clearAuthToken, getAuthToken } from '@/shared/lib/auth-token';
 import { clearSessionUser, getSessionUserFromStorage, setSessionUser } from '@/shared/lib/session-user';
 
 export const AuthBootstrap = () => {
   const didRun = useRef(false);
-  const router = useRouter();
 
   useEffect(() => {
     if (didRun.current) {
@@ -28,7 +25,7 @@ export const AuthBootstrap = () => {
     void getMyProfile()
       .then((profile) => {
         if (!profile.username?.trim()) {
-          router.replace(ROUTES.SIGNUP);
+          clearAuthToken();
           return;
         }
         setSessionUser(mapProfileToSessionUser(profile));
@@ -39,7 +36,7 @@ export const AuthBootstrap = () => {
           clearSessionUser();
         }
       });
-  }, [router]);
+  }, []);
 
   return null;
 };

--- a/shared/providers/auth-bootstrap.tsx
+++ b/shared/providers/auth-bootstrap.tsx
@@ -1,15 +1,18 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 
 import { getMyProfile } from '@/features/auth/fetchers';
 import { mapProfileToSessionUser } from '@/features/auth/lib/map-profile-to-session';
+import { ROUTES } from '@/shared/constants/routes';
 import { ApiError } from '@/shared/lib/api';
 import { clearAuthToken, getAuthToken } from '@/shared/lib/auth-token';
 import { clearSessionUser, getSessionUserFromStorage, setSessionUser } from '@/shared/lib/session-user';
 
 export const AuthBootstrap = () => {
   const didRun = useRef(false);
+  const router = useRouter();
 
   useEffect(() => {
     if (didRun.current) {
@@ -23,14 +26,20 @@ export const AuthBootstrap = () => {
     }
 
     void getMyProfile()
-      .then((profile) => setSessionUser(mapProfileToSessionUser(profile)))
+      .then((profile) => {
+        if (!profile.username?.trim()) {
+          router.replace(ROUTES.SIGNUP);
+          return;
+        }
+        setSessionUser(mapProfileToSessionUser(profile));
+      })
       .catch((error) => {
         if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
           clearAuthToken();
           clearSessionUser();
         }
       });
-  }, []);
+  }, [router]);
 
   return null;
 };


### PR DESCRIPTION
# 📝 개요
탈퇴 후 카카오 재로그인 시 회원가입 동의 절차를 완료하지 않아도카카오 이메일 앞부분이 닉네임으로 세팅된 세션이 자동 생성되어, 사실상 동의 없이 로그인된 상태로 모든 기능에 접근 가능했던 버그를 수정했습니다

### 원인
  - `completeLoginSession`에서 `needsOnboarding = true`인 경우에도 이메일 prefix를 닉네임으로 fallback하는 가짜 세션을 생성하고 있었음
  - `AuthBootstrap`이 토큰은 있지만 세션이 없는 상태를 복원 시도하면서 동일하게 가짜 세션을 재생성하고 있었음

### 수정
  - `completeLoginSession`: 온보딩 미완료 유저에게는 세션을 생성하지 않도록 변경
  - `AuthBootstrap`: `username`이 없는 토큰 감지 시 리다이렉트 대신 토큰 제거로 변경
    → 창을 닫고 다시 열었을 때 강제로 가입 화면으로 끌려가는 부작용도 함께 해소

이에 대한 테스트는 배포사이트 연동으로 이미 완료한 상태입니다. (※현재 배포사이트는 feature/199-ga 기준으로 되어있어 지금 변경사항이 반영되어 있지 않은 점 참고바람)
(추가작업: 회원가입 폼 한 줄 소개 필드에 필수 항목 표시(`*`) 추가)
## 🔗 관련 이슈

- Closes #197 

## 🛠️ 변경 사항 (Checklist)

- [ ] ✨ Feature: 새로운 기능 추가
- [ ] 🚀 Enhancement: 기존 기능 개선/성능 향상
- [x] 🐞 Bug: 버그 수정
- [ ] ♻️ Refactor: 코드 구조 개선 (기능 변화 없음)
- [ ] 🏗️ Chore: 빌드/패키지 설정/단순 잡일
- [ ] 🎨 Design: UI/UX 스타일 수정
- [ ] 📚 Documentation: 문서 수정

## ✅ 아래 내용을 한 번 더 점검해 주세요

### 1. 의도와 가독성 (Naming & Readability)

- [ ] **의도 중심 네이밍**: 변수명에서 '역할'이, 함수명에서 '행위+대상'이 명확히 드러나나요?
- [ ] **선언적 코드**: '어떻게'가 아닌 '무엇을' 하는지 코드만 보고도 알 수 있나요? (복잡한 로직은 내부 메서드로 숨겼나요?)
- [ ] **주석**: 코드만으로 설명이 어려운 '특정 로직'에만 주석을 달았나요?

### 2. 타입과 논리 (Type Safety & Logic)

- [ ] **타입 안전성**: `any` 사용을 지양하고, 모든 함수의 반환 타입을 명시했나요?
- [ ] **엣지 케이스**: 데이터가 없거나(`null/undefined`), 에러가 발생할 경우를 처리했나요?
- [ ] **하드코딩 방지**: API 주소나 설정값들이 환경 변수나 상수로 분리되었나요?

### 3. 코드 다이어트 (Clean-up)

- [ ] **찌꺼기 제거**: 디버깅용 `console.log`나 사용하지 않는 `import`를 모두 지웠나요?
- [ ] **불필요한 코드**: "나중에 쓰겠지" 하고 남겨둔 죽은 코드(Dead Code)는 없나요?
- [ ] **Linter**: 린트 에러나 워닝이 남아있지 않나요?

### 4. 지속 가능성 (Sustainability)

- [ ] **테스트**: 수동으로든 코드로든 정상 작동을 확인했나요? (특히 기존 기능이 망가지지 않았나요?)
- [ ] **문서화**: 새로운 환경 변수나 라이브러리가 추가되어 `README` 업데이트가 필요한가요?

---

## 💭 회고 (Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 회원가입 시 자기소개 입력이 필수 항목으로 변경되었습니다.

* **Bug Fixes**
  * 로그인 세션 설정 시 프로필 유효성 검증이 강화되었습니다.
  * 유효하지 않은 프로필 정보 감지 시 인증이 안전하게 초기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->