### PR TITLE
fix: myProfile Suspense SSR로 hydration mismatch 및 guest 500 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ next-env.d.ts
 
 # Sentry Config File
 .env.sentry-build-plugin
+
+# local SSR guide (not tracked)
+docs/tanstack-query-ssr.md

--- a/app/(home)/home-hero-section.tsx
+++ b/app/(home)/home-hero-section.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { Suspense } from 'react';
 
 import { Button } from '@/shared/components/button/button';
 import { PageContainer } from '@/shared/components/page-container';
@@ -25,7 +26,15 @@ export const HomeHeroSection = () => {
           <Button asChild variant="primary" size="large">
             <ProtectedLink href="/projects">프로젝트 시작하기</ProtectedLink>
           </Button>
-          <HomeProfileButton />
+          <Suspense
+            fallback={
+              <Button variant="tertiary" size="large" disabled>
+                내 프로필 보기
+              </Button>
+            }
+          >
+            <HomeProfileButton />
+          </Suspense>
         </div>
       </div>
 

--- a/app/(home)/home-profile-button.tsx
+++ b/app/(home)/home-profile-button.tsx
@@ -7,9 +7,11 @@ import { ROUTES } from '@/shared/constants/routes';
 
 export const HomeProfileButton = () => {
   const { data: profile } = useMyProfile();
+  const profileHref = profile ? ROUTES.PROFILE(profile.userId) : '/profile';
+
   return (
     <Button asChild variant="tertiary" size="large">
-      <ProtectedLink href={ROUTES.PROFILE(profile?.userId ?? '')}>내 프로필 보기</ProtectedLink>
+      <ProtectedLink href={profileHref}>내 프로필 보기</ProtectedLink>
     </Button>
   );
 };

--- a/app/(protected)/projects/page.tsx
+++ b/app/(protected)/projects/page.tsx
@@ -2,7 +2,7 @@ import { dehydrate } from '@tanstack/react-query';
 import { cookies } from 'next/headers';
 import { Suspense } from 'react';
 
-import { fetchMyProfile } from '@/features/profile/api/fetch-my-profile';
+import { fetchMyProfileOptional } from '@/features/profile/api/fetch-my-profile-optional';
 import { buildReviewRequestDescription } from '@/features/profile/lib/profile-share-content';
 import { profileKeys } from '@/features/profile/profile.query-keys';
 import { fetchProjects } from '@/features/project/api/fetchers';
@@ -62,7 +62,10 @@ const ProjectsPage = async () => {
     try {
       await Promise.all([
         queryClient.prefetchQuery({ queryKey: projectKeys.list(), queryFn: fetchProjects }),
-        queryClient.prefetchQuery({ queryKey: profileKeys.my, queryFn: fetchMyProfile }),
+        queryClient.prefetchQuery({
+          queryKey: profileKeys.my,
+          queryFn: () => fetchMyProfileOptional({ headers: { Cookie: cookieStore.toString() } }),
+        }),
       ]);
     } catch {
       // 비로그인·만료 세션 등 prefetch 실패 시에도 초대 링크 랜딩은 허용

--- a/app/_components/header/header-auth-area-client.tsx
+++ b/app/_components/header/header-auth-area-client.tsx
@@ -7,7 +7,6 @@ import { Avatar } from 'radix-ui';
 import { useState } from 'react';
 
 import { useMyProfile } from '@/features/profile/hooks/use-my-profile.query';
-import type { Profile } from '@/features/profile/profile.types';
 import { KakaoLoginButton } from '@/shared/components/button/kakao-login-button';
 import { Dropdown } from '@/shared/components/dropdown';
 import { NotificationBell } from '@/shared/components/notification';
@@ -19,16 +18,12 @@ const DEFAULT_AVATAR_SRC = '/sample_user.svg';
 const dropdownItemClassName =
   'text-body-sm text-text-basic !h-[44px] min-h-0 shrink-0 justify-start rounded-md px-2 py-0 font-normal';
 
-interface Props {
-  initialProfile: Profile;
-}
-
-export const HeaderAuthAreaClient = ({ initialProfile }: Props) => {
+export const HeaderAuthAreaClient = () => {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { data: queryProfile } = useMyProfile();
+  const { data: profileFromQuery } = useMyProfile();
   const [hasLoggedOut, setHasLoggedOut] = useState(false);
-  const profile = hasLoggedOut ? null : (queryProfile ?? initialProfile);
+  const profile = hasLoggedOut ? null : profileFromQuery;
 
   if (!profile) {
     return <KakaoLoginButton />;

--- a/app/_components/header/header-auth-area.tsx
+++ b/app/_components/header/header-auth-area.tsx
@@ -1,16 +1,13 @@
-import type { Profile } from '@/features/profile/profile.types';
+import { Suspense } from 'react';
+
 import { KakaoLoginButton } from '@/shared/components/button/kakao-login-button';
 
 import { HeaderAuthAreaClient } from './header-auth-area-client';
 
-interface Props {
-  initialProfile: Profile | null;
-}
-
-export const HeaderAuthArea = ({ initialProfile }: Props) => {
-  if (initialProfile === null) {
-    return <KakaoLoginButton />;
-  }
-
-  return <HeaderAuthAreaClient initialProfile={initialProfile} />;
+export const HeaderAuthArea = () => {
+  return (
+    <Suspense fallback={<KakaoLoginButton />}>
+      <HeaderAuthAreaClient />
+    </Suspense>
+  );
 };

--- a/app/_components/header/header.tsx
+++ b/app/_components/header/header.tsx
@@ -1,50 +1,28 @@
-import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
-import { cookies } from 'next/headers';
 import Image from 'next/image';
 import Link from 'next/link';
-
-import { fetchMyProfile } from '@/features/profile/api/fetch-my-profile';
-import { profileKeys } from '@/features/profile/profile.query-keys';
-import type { Profile } from '@/features/profile/profile.types';
-import { getQueryClient } from '@/shared/lib/get-query-client';
+import { Suspense } from 'react';
 
 import { HeaderAuthArea } from './header-auth-area';
 import { HeaderMainNav } from './header-main-nav';
 
 /**
  * 헤더 (Server Component).
- * 로그인 상태에 따라 헤더 영역을 동적으로 렌더링한다.
+ * myProfile prefetch는 MainLayout 전역 HydrationBoundary에서 처리한다.
  */
-export const Header = async () => {
-  const queryClient = getQueryClient();
-  const cookieStore = await cookies();
-
-  await queryClient.prefetchQuery({
-    queryKey: profileKeys.my,
-    queryFn: () => fetchMyProfile({ headers: { Cookie: cookieStore.toString() } }),
-  });
-  const profile = queryClient.getQueryData<Profile>(profileKeys.my) ?? null;
-
+export const Header = () => {
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
-      <header className="bg-gray-0/95 sticky top-0 z-50 border-b border-gray-200 backdrop-blur-sm">
-        <div className="mx-auto flex h-14 w-full max-w-[1200px] items-center justify-between gap-4 px-4 sm:h-16 sm:gap-6 sm:px-6 lg:px-0">
-          <div className="flex min-w-0 items-center gap-6">
-            <Link href="/" className="relative flex h-[36px] shrink-0 items-center">
-              <Image
-                src="/Sossbar_logo.svg"
-                alt="Sossbar"
-                width={161}
-                height={36}
-                className="h-[36px] w-auto"
-                priority
-              />
-            </Link>
+    <header className="bg-gray-0/95 sticky top-0 z-50 border-b border-gray-200 backdrop-blur-sm">
+      <div className="mx-auto flex h-14 w-full max-w-[1200px] items-center justify-between gap-4 px-4 sm:h-16 sm:gap-6 sm:px-6 lg:px-0">
+        <div className="flex min-w-0 items-center gap-6">
+          <Link href="/" className="relative flex h-[36px] shrink-0 items-center">
+            <Image src="/Sossbar_logo.svg" alt="Sossbar" width={161} height={36} className="h-[36px] w-auto" priority />
+          </Link>
+          <Suspense fallback={<div className="h-10 w-48" aria-hidden />}>
             <HeaderMainNav />
-          </div>
-          <HeaderAuthArea initialProfile={profile} />
+          </Suspense>
         </div>
-      </header>
-    </HydrationBoundary>
+        <HeaderAuthArea />
+      </div>
+    </header>
   );
 };

--- a/app/_components/main-layout-client.tsx
+++ b/app/_components/main-layout-client.tsx
@@ -3,9 +3,7 @@
 import type { ReactNode } from 'react';
 
 import { usePathname } from 'next/navigation';
-import { Suspense } from 'react';
 
-import { LoginModal } from '@/shared/components/dialog/login-modal';
 import { Footer } from '@/shared/components/footer';
 
 interface Props {
@@ -32,10 +30,6 @@ export const MainLayoutClient = ({ children, header }: Props) => {
       {header}
       <main className="flex-1">{children}</main>
       <Footer variant={footerVariant} />
-      {/* useLoginModal → useSearchParams 사용으로 Suspense boundary 필요 */}
-      <Suspense fallback={null}>
-        <LoginModal />
-      </Suspense>
     </>
   );
 };

--- a/app/_components/main-layout.tsx
+++ b/app/_components/main-layout.tsx
@@ -1,8 +1,14 @@
 import type { ReactNode } from 'react';
 
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import { cookies } from 'next/headers';
 import { Suspense } from 'react';
 
+import { fetchMyProfileOptional } from '@/features/profile/api/fetch-my-profile-optional';
+import { profileKeys } from '@/features/profile/profile.query-keys';
+import { LoginModal } from '@/shared/components/dialog/login-modal';
 import { GoogleAnalyticsPageView } from '@/shared/components/google-analytics-page-view';
+import { getQueryClient } from '@/shared/lib/get-query-client';
 
 import { Header } from './header/header';
 import { MainLayoutClient } from './main-layout-client';
@@ -13,13 +19,28 @@ interface Props {
 
 /**
  * 앱 전역 페이지 틀 (Server Component).
- * GA 페이지뷰 + 클라이언트 레이아웃(헤더·푸터·로그인 모달)을 감싼다.
+ * myProfile prefetch + HydrationBoundary로 전역 Client subtree에 suspense query 캐시를 공급한다.
  */
-export const MainLayout = ({ children }: Props) => {
+export const MainLayout = async ({ children }: Props) => {
+  const cookieStore = await cookies();
+  const queryClient = getQueryClient();
+
+  await queryClient.prefetchQuery({
+    queryKey: profileKeys.my,
+    queryFn: () => fetchMyProfileOptional({ headers: { Cookie: cookieStore.toString() } }),
+  });
+
   return (
-    <Suspense fallback={null}>
-      <GoogleAnalyticsPageView />
-      <MainLayoutClient header={<Header />}>{children}</MainLayoutClient>
-    </Suspense>
+    <>
+      <Suspense fallback={null}>
+        <GoogleAnalyticsPageView />
+      </Suspense>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <MainLayoutClient header={<Header />}>{children}</MainLayoutClient>
+        <Suspense fallback={null}>
+          <LoginModal />
+        </Suspense>
+      </HydrationBoundary>
+    </>
   );
 };

--- a/features/profile/api/fetch-my-profile-optional.ts
+++ b/features/profile/api/fetch-my-profile-optional.ts
@@ -1,0 +1,23 @@
+import { ApiError, type ApiRequestOptions } from '@/shared/lib/api';
+
+import type { Profile } from '../profile.types';
+
+import { fetchMyProfile } from './fetch-my-profile';
+
+/** 미로그인·인증 실패 시 API가 반환하는 HTTP status (guest → `null`) */
+const UNAUTHENTICATED_STATUSES = new Set([401, 403]);
+
+/**
+ * 내 프로필 조회. 미로그인(401/403)은 에러 대신 `null`을 반환한다.
+ * SSR prefetch·useSuspenseQuery에서 guest/session 만료를 안전하게 처리하기 위함.
+ */
+export const fetchMyProfileOptional = async (init?: ApiRequestOptions): Promise<Profile | null> => {
+  try {
+    return await fetchMyProfile(init);
+  } catch (error) {
+    if (error instanceof ApiError && UNAUTHENTICATED_STATUSES.has(error.status)) {
+      return null;
+    }
+    throw error;
+  }
+};

--- a/features/profile/hooks/use-my-profile.query.ts
+++ b/features/profile/hooks/use-my-profile.query.ts
@@ -1,12 +1,11 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
-import { fetchMyProfile } from '../api/fetch-my-profile';
+import { fetchMyProfileOptional } from '../api/fetch-my-profile-optional';
 import { profileKeys } from '../profile.query-keys';
 
 export const useMyProfile = () => {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: profileKeys.my,
-    queryFn: () => fetchMyProfile(),
-    throwOnError: false,
+    queryFn: () => fetchMyProfileOptional(),
   });
 };

--- a/features/project/components/project-invite-handler.tsx
+++ b/features/project/components/project-invite-handler.tsx
@@ -25,14 +25,14 @@ export const ProjectInviteHandler = () => {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { data: profile, isPending: isProfilePending } = useMyProfile();
+  const { data: profile } = useMyProfile();
   const { openLoginModal } = useLoginModal();
 
   const projectId = useMemo(() => parseProjectInviteId(searchParams.get(PROJECT_INVITE_QUERY_KEY)), [searchParams]);
 
   const [joinError, setJoinError] = useState<string | null>(null);
 
-  const hasSession = !isProfilePending && profile != null;
+  const hasSession = profile != null;
 
   const clearInviteParam = useCallback(() => {
     if (searchParams.get(PROJECT_INVITE_QUERY_KEY) == null) {

--- a/shared/components/dialog/login-modal.tsx
+++ b/shared/components/dialog/login-modal.tsx
@@ -12,7 +12,7 @@ const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${proc
 
 export const LoginModal = () => {
   const { data: profile } = useMyProfile();
-  const { isOpen, onOpenChange } = useLoginModal({ isAuthenticated: profile !== null && profile !== undefined });
+  const { isOpen, onOpenChange } = useLoginModal({ isAuthenticated: profile != null });
 
   const handleKakaoLogin = () => {
     saveLoginReturnPath();

--- a/shared/components/protected-link/use-protected-link-click.ts
+++ b/shared/components/protected-link/use-protected-link-click.ts
@@ -1,14 +1,27 @@
+'use client';
+
 import type { ComponentProps, MouseEventHandler } from 'react';
 
+import { saveLoginReturnPath } from '@/features/auth/lib/login-return-path';
 import { useMyProfile } from '@/features/profile';
-import { useLoginModal } from '@/shared/hooks/use-login-modal';
 
 import type Link from 'next/link';
 
+const LOGIN_MODAL_PARAM = 'login';
+
+const openLoginModalViaUrl = () => {
+  saveLoginReturnPath();
+  const params = new URLSearchParams(window.location.search);
+  params.set('modal', LOGIN_MODAL_PARAM);
+  const query = params.toString();
+  const nextUrl = query ? `${window.location.pathname}?${query}` : window.location.pathname;
+  window.history.pushState(null, '', nextUrl);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+};
+
 export const useProtectedLinkClick = (onClick: ComponentProps<typeof Link>['onClick']) => {
   const { data: profile } = useMyProfile();
-  const isAuthenticated = profile !== null && profile !== undefined;
-  const { openLoginModal } = useLoginModal({ isAuthenticated });
+  const isAuthenticated = profile != null;
 
   const handleClick: MouseEventHandler<HTMLAnchorElement> = (event) => {
     onClick?.(event);
@@ -17,7 +30,7 @@ export const useProtectedLinkClick = (onClick: ComponentProps<typeof Link>['onCl
     }
 
     event.preventDefault();
-    openLoginModal();
+    openLoginModalViaUrl();
   };
 
   return handleClick;


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issues)

- Issue Closes #235

## 📋 작업 내용 (Description)

- `fetchMyProfileOptional` 추가: 미로그인 API 401/403 → `null`
- `useMyProfile` `useSuspenseQuery` 전환
- `MainLayout` 전역 `cookies()` prefetch + `HydrationBoundary`
- Header prefetch 중복 제거, `HeaderAuthArea`·홈·`LoginModal` Suspense boundary
- `ProtectedLink` 로그인 모달 URL param 방식 개선
- projects·invite handler guest myProfile 처리 정리

## 🛠️ 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 추가 (New Feature)
- [x] 🚀 성능 개선 및 리팩토링 (Refactor & Enhancement)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] 📚 문서 수정 (Documentation)
- [x] 🏗️ 빌드/환경 설정 (Build/Chore)

## ✅ 체크리스트 (Self-Check)

- [x] 코드가 정상적으로 빌드 및 실행되나요?
- [x] 기존 기능에 영향을 주지 않나요? (Side Effect 확인)
- [x] 불필요한 콘솔 로그(console.log)나 주석을 제거했나요?
- [x] 변수명, 함수명은 직관적인가요? (Clean Code)

## 📸 스크린샷 (Screenshots - Optional)

|           Before           |           After            |
| :------------------------: | :------------------------: |
| 비로그인 홈 500 / href hydration mismatch | 비로그인 홈 정상 렌더, 로그인 시 href 일치 |

Made with [Cursor](https://cursor.com)