### PR TITLE
fix: 만료된 세션으로 protected 라우트 접근 차단

### DIFF
--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react';
+
+import { cookies, headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+import { fetchMyProfileOptional } from '@/features/profile';
+import {
+  isCrawlerUserAgent,
+  isPublicShareRoute,
+  ROUTE_PATHNAME_HEADER,
+  ROUTE_SEARCH_HEADER,
+} from '@/shared/lib/route-access';
+
+interface Props {
+  children: ReactNode;
+}
+
+const ProtectedLayout = async ({ children }: Props) => {
+  const headersList = await headers();
+  const pathname = headersList.get(ROUTE_PATHNAME_HEADER) ?? '';
+  const searchParams = new URLSearchParams(headersList.get(ROUTE_SEARCH_HEADER) ?? '');
+
+  const isOgCrawlerProfile = pathname.startsWith('/profile/') && isCrawlerUserAgent(headersList.get('user-agent'));
+
+  if (isPublicShareRoute(pathname, searchParams) || isOgCrawlerProfile) {
+    return children;
+  }
+
+  const cookieStore = await cookies();
+  const profile = await fetchMyProfileOptional({ headers: { Cookie: cookieStore.toString() } });
+
+  if (!profile) {
+    redirect('/');
+  }
+
+  return children;
+};
+
+export default ProtectedLayout;

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,39 +1,24 @@
 import { NextResponse } from 'next/server';
 
+import {
+  isCrawlerUserAgent,
+  isPublicShareRoute,
+  ROUTE_PATHNAME_HEADER,
+  ROUTE_SEARCH_HEADER,
+} from '@/shared/lib/route-access';
+
 import type { NextRequest } from 'next/server';
 
 const RETURN_PATH_COOKIE = 'sossbar-login-return';
 
 const PROTECTED_PREFIXES = ['/mypage', '/my-soss', '/personal', '/projects', '/reviews', '/profile', '/signup'];
 
-const CRAWLER_UA_PATTERNS = [
-  'facebookexternalhit',
-  'twitterbot',
-  'linkedinbot',
-  'slackbot',
-  'telegrambot',
-  'whatsapp',
-  'kakaotalk',
-  'googlebot',
-  'bingbot',
-];
+const continueWithPathHeaders = (request: NextRequest) => {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set(ROUTE_PATHNAME_HEADER, request.nextUrl.pathname);
+  requestHeaders.set(ROUTE_SEARCH_HEADER, request.nextUrl.searchParams.toString());
 
-const isCrawler = (request: NextRequest): boolean => {
-  const ua = (request.headers.get('user-agent') ?? '').toLowerCase();
-  return CRAWLER_UA_PATTERNS.some((pattern) => ua.includes(pattern));
-};
-
-/** OG 크롤러·초대 링크 수신자가 로그인 없이 접근해야 하는 경로 */
-const isPublicShareRoute = (pathname: string, searchParams: URLSearchParams): boolean => {
-  if (pathname === '/projects' && searchParams.has('inviteProjectId')) {
-    return true;
-  }
-
-  if (pathname === '/reviews/new' && searchParams.has('projectId') && searchParams.has('revieweeId')) {
-    return true;
-  }
-
-  return false;
+  return NextResponse.next({ request: { headers: requestHeaders } });
 };
 
 export const proxy = (request: NextRequest) => {
@@ -41,20 +26,22 @@ export const proxy = (request: NextRequest) => {
 
   const isProtected = PROTECTED_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`));
 
-  if (!isProtected || request.cookies.has('accessToken')) {
-    return NextResponse.next();
+  if (!isProtected) {
+    return continueWithPathHeaders(request);
   }
 
   if (isPublicShareRoute(pathname, searchParams)) {
-    return NextResponse.next();
+    return continueWithPathHeaders(request);
   }
 
-  // 크롤러는 OG 메타데이터 수집을 위해 통과
-  if (pathname.startsWith('/profile/') && isCrawler(request)) {
-    return NextResponse.next();
+  if (pathname.startsWith('/profile/') && isCrawlerUserAgent(request.headers.get('user-agent'))) {
+    return continueWithPathHeaders(request);
   }
 
-  // 공유 프로필: 홈 화면 위에 로그인 팝업 표시 + 복귀 경로 저장
+  if (request.cookies.has('accessToken')) {
+    return continueWithPathHeaders(request);
+  }
+
   if (pathname.startsWith('/profile/')) {
     const query = searchParams.toString();
     const returnPath = query ? `${pathname}?${query}` : pathname;

--- a/shared/lib/route-access.ts
+++ b/shared/lib/route-access.ts
@@ -1,0 +1,33 @@
+/** OG 크롤러·초대/후기 링크 등 로그인 없이 접근해야 하는 경로 */
+export const isPublicShareRoute = (pathname: string, searchParams: URLSearchParams): boolean => {
+  if (pathname === '/projects' && searchParams.has('inviteProjectId')) {
+    return true;
+  }
+
+  if (pathname === '/reviews/new' && searchParams.has('projectId') && searchParams.has('revieweeId')) {
+    return true;
+  }
+
+  return false;
+};
+
+const CRAWLER_UA_PATTERNS = [
+  'facebookexternalhit',
+  'twitterbot',
+  'linkedinbot',
+  'slackbot',
+  'telegrambot',
+  'whatsapp',
+  'kakaotalk',
+  'googlebot',
+  'bingbot',
+] as const;
+
+export const isCrawlerUserAgent = (userAgent: string | null): boolean => {
+  const ua = (userAgent ?? '').toLowerCase();
+  return CRAWLER_UA_PATTERNS.some((pattern) => ua.includes(pattern));
+};
+
+/** proxy → layout에 pathname·query 전달용 헤더 */
+export const ROUTE_PATHNAME_HEADER = 'x-pathname';
+export const ROUTE_SEARCH_HEADER = 'x-search';


### PR DESCRIPTION
# 📝 개요

- 리프레시 토큰 만료 후 `accessToken` 쿠키만 남아 있을 때 `(protected)` 페이지에 접근되던 문제를 수정
- `(protected)/layout.tsx`에서 `fetchMyProfileOptional`로 세션 유효성 검증, 실패 시 `/` redirect
- 초대/후기 링크·OG 크롤러 예외 로직을 `shared/lib/route-access.ts`로 추출해 proxy·layout 공유

## 🔗 관련 이슈

- Closes #278

## 🛠️ 변경 사항 (Checklist)

- [ ] ✨ Feature: 새로운 기능 추가
- [ ] 🚀 Enhancement: 기존 기능 개선/성능 향상
- [x] 🐞 Bug: 버그 수정
- [ ] ♻️ Refactor: 코드 구조 개선 (기능 변화 없음)
- [ ] 🏗️ Chore: 빌드/패키지 설정/단순 잡일
- [ ] 🎨 Design: UI/UX 스타일 수정
- [ ] 📚 Documentation: 문서 수정

## Test plan

- [ ] 로그아웃 후 `/my-soss` URL 직접 접근 → `/` redirect
- [ ] 만료된 accessToken 쿠키만 있는 상태에서 `/my-soss` 접근 → `/` redirect (500 아님)
- [ ] `/projects?inviteProjectId=…` 비로그인 접근 → 정상 (초대 랜딩)
- [ ] `/reviews/new?projectId=…&revieweeId=…` 비로그인 접근 → 정상 (후기 작성)
- [ ] 로그인 상태에서 `/my-soss`, `/mypage` 정상 접근

Made with [Cursor](https://cursor.com)