### PR TITLE
refactor: profile 응답 스키마 정합화 및 userLink 기반 조회 전환

### DIFF
--- a/app/(protected)/my-soss/page.tsx
+++ b/app/(protected)/my-soss/page.tsx
@@ -40,7 +40,7 @@ const Page = async () => {
         }
         projectsTabContent={
           <Suspense fallback={<ProjectSectionSkeleton />}>
-            <ProjectSectionStream userId={myProfile.userId} />
+            <ProjectSectionStream userId={myProfile.userId} userLink={myProfile.userLink} />
           </Suspense>
         }
       />

--- a/app/(protected)/profile/[userLink]/page.tsx
+++ b/app/(protected)/profile/[userLink]/page.tsx
@@ -18,31 +18,27 @@ import { SpectrumCardEntry, SpectrumCardLoading } from '@/features/spectrum';
 import { TagCardEntry, TagCardLoading } from '@/features/tag';
 import { PageContainer } from '@/shared/components/page-container';
 import { SHARE_USER_NAME_PARAM } from '@/shared/constants/share-query';
-import { parsePositiveInt } from '@/shared/lib/parse-positive-int';
 import { parseShareDisplayName } from '@/shared/lib/parse-share-display-name';
 
 import type { Metadata } from 'next';
 
 type ProfilePageProps = {
   params: Promise<{
-    userId: string;
+    userLink: string;
   }>;
   searchParams: Promise<{
     [SHARE_USER_NAME_PARAM]?: string;
   }>;
 };
 
-const resolveProfileShareUserName = async (
-  profileUserId: number,
-  queryUserName?: string,
-): Promise<string | undefined> => {
+const resolveProfileShareUserName = async (userLink: string, queryUserName?: string): Promise<string | undefined> => {
   const fromQuery = parseShareDisplayName(queryUserName);
   if (fromQuery) {
     return fromQuery;
   }
 
   try {
-    const profile = await fetchProfileById(profileUserId);
+    const profile = await fetchProfileById(userLink);
     return profile.username;
   } catch {
     return undefined;
@@ -50,15 +46,10 @@ const resolveProfileShareUserName = async (
 };
 
 export const generateMetadata = async ({ params, searchParams }: ProfilePageProps): Promise<Metadata> => {
-  const { userId } = await params;
+  const { userLink } = await params;
   const { [SHARE_USER_NAME_PARAM]: rawUserName } = await searchParams;
-  const profileUserId = parsePositiveInt(userId);
 
-  if (profileUserId === null) {
-    return { title: '프로필' };
-  }
-
-  const userName = await resolveProfileShareUserName(profileUserId, rawUserName);
+  const userName = await resolveProfileShareUserName(userLink, rawUserName);
   const queryUserName = parseShareDisplayName(rawUserName);
   const pathSearchParams = new URLSearchParams();
 
@@ -67,35 +58,32 @@ export const generateMetadata = async ({ params, searchParams }: ProfilePageProp
   }
 
   const profilePath =
-    pathSearchParams.size > 0
-      ? `/profile/${profileUserId}?${pathSearchParams.toString()}`
-      : `/profile/${profileUserId}`;
+    pathSearchParams.size > 0 ? `/profile/${userLink}?${pathSearchParams.toString()}` : `/profile/${userLink}`;
 
-  return buildProfileShareMetadata(profileUserId, userName, profilePath);
+  return buildProfileShareMetadata(userLink, userName, profilePath);
 };
 
 const Page = async ({ params }: ProfilePageProps) => {
-  const { userId } = await params;
-  const profileUserId = parsePositiveInt(userId);
+  const { userLink } = await params;
 
-  if (profileUserId === null) {
+  if (!userLink) {
     return notFound();
   }
 
   const cookieStore = await cookies();
   const [profile, myProfile] = await Promise.all([
-    fetchProfileById(profileUserId),
+    fetchProfileById(userLink),
     fetchMyProfile({ headers: { Cookie: cookieStore.toString() } }).catch(() => null),
   ]);
-  const isMyProfile = myProfile?.userId === profileUserId;
+  const isMyProfile = myProfile?.userLink === userLink;
 
   return (
     <PageContainer className="mb-20">
       <Suspense fallback={<ProfileSectionLoading />}>
-        <ProfileByIdSectionEntry userId={profileUserId} isMyProfile={isMyProfile} />
+        <ProfileByIdSectionEntry userLink={userLink} isMyProfile={isMyProfile} />
       </Suspense>
       <ProfileDetailView
-        userId={profileUserId}
+        userId={profile.userId}
         allTabContent={
           <>
             <div className="flex gap-[30px]">
@@ -107,13 +95,13 @@ const Page = async ({ params }: ProfilePageProps) => {
               </Suspense>
             </div>
             <Suspense fallback={<UserReviewContainerSkeleton />}>
-              <UserReviewStream userId={profileUserId} />
+              <UserReviewStream userId={profile.userId} />
             </Suspense>
           </>
         }
         projectsTabContent={
           <Suspense fallback={<ProjectSectionSkeleton />}>
-            <ProjectSectionStream userId={profileUserId} />
+            <ProjectSectionStream userId={profile.userId} userLink={profile.userLink} />
           </Suspense>
         }
       />

--- a/app/(protected)/profile/[userLink]/project/[projectId]/page.tsx
+++ b/app/(protected)/profile/[userLink]/project/[projectId]/page.tsx
@@ -7,16 +7,15 @@ import { getQueryClient } from '@/shared/lib/get-query-client';
 
 interface Props {
   params: Promise<{
-    userId: string;
+    userLink: string;
     projectId: string;
   }>;
 }
 
 const ProjectPage = async ({ params }: Props) => {
-  const { userId, projectId } = await params;
+  const { userLink, projectId } = await params;
   const queryClient = getQueryClient();
 
-  const profileUserId = Number(userId);
   const projectIdNum = Number(projectId);
 
   const [, , profile] = await Promise.all([
@@ -26,14 +25,14 @@ const ProjectPage = async ({ params }: Props) => {
     }),
     queryClient.prefetchQuery({ queryKey: profileKeys.my, queryFn: fetchMyProfile }),
     queryClient.fetchQuery({
-      queryKey: profileKeys.detail(profileUserId),
-      queryFn: () => fetchProfileById(profileUserId),
+      queryKey: profileKeys.detail(userLink),
+      queryFn: () => fetchProfileById(userLink),
     }),
   ]);
 
   return (
     <ProjectDetailStream
-      userId={profileUserId}
+      userId={profile.userId}
       userLink={profile.userLink}
       projectId={projectIdNum}
       state={dehydrate(queryClient)}

--- a/app/(public)/profile-examples/page.tsx
+++ b/app/(public)/profile-examples/page.tsx
@@ -3,14 +3,14 @@ import { PageContainer } from '@/shared/components/page-container';
 
 import { ProfileExamplesClient } from './profile-examples-client';
 
-const DEMO_PROFILE_USER_ID = 1;
+const DEMO_PROFILE_USER_LINK = '1';
 
 const ProfileExamplesPage = async () => {
-  const profile = await fetchProfileById(DEMO_PROFILE_USER_ID);
+  const profile = await fetchProfileById(DEMO_PROFILE_USER_LINK);
 
   return (
     <PageContainer className="mb-20">
-      <ProfileExamplesClient userId={DEMO_PROFILE_USER_ID} userLink={profile.userLink} />
+      <ProfileExamplesClient userId={profile.userId} userLink={profile.userLink} />
     </PageContainer>
   );
 };

--- a/app/(public)/profile-examples/profile-examples-client.tsx
+++ b/app/(public)/profile-examples/profile-examples-client.tsx
@@ -14,7 +14,7 @@ interface Props {
 export const ProfileExamplesClient = ({ userId, userLink }: Props) => {
   return (
     <>
-      <ProfileByIdSectionGate userId={userId} />
+      <ProfileByIdSectionGate userLink={userLink} />
       <ProfileDetailView
         userId={userId}
         allTabContent={
@@ -26,7 +26,7 @@ export const ProfileExamplesClient = ({ userId, userLink }: Props) => {
             <UserReviewContainerBoundary userId={userId} />
           </>
         }
-        projectsTabContent={<ProjectSection userId={userId} />}
+        projectsTabContent={<ProjectSection userId={userId} userLink={userLink} />}
       />
     </>
   );

--- a/features/auth/index.ts
+++ b/features/auth/index.ts
@@ -1,6 +1,6 @@
 export { exchangeKakaoCode, fetchNeedsOnboarding } from './auth.api';
 export { LOGIN_RETURN_COOKIE_NAME, USER_LINK_TYPE_OPTIONS, USER_LINKS_MAX } from './auth.constants';
-export type { UserLinkType } from './auth.types';
+export type { PositionValue, UserLinkType } from './auth.types';
 export { useLoginGate } from './login-modal.hooks';
 export { openLoginModalOnPage, resolveKakaoLoginDestination, saveLoginReturnPath } from './auth.lib';
 export { AccountDeletionModal } from './components/account-deletion-modal';

--- a/features/profile/components/header-my-profile.tsx
+++ b/features/profile/components/header-my-profile.tsx
@@ -8,7 +8,7 @@ import { Dropdown } from '@/shared/components/dropdown';
 import { ROUTES } from '@/shared/constants/routes';
 import { cn } from '@/shared/lib/cn';
 
-import type { Profile } from '../profile.types';
+import type { MyProfile } from '../profile.types';
 
 const DEFAULT_AVATAR_SRC = '/sample_user.svg';
 
@@ -16,7 +16,7 @@ const dropdownItemClassName =
   'text-body-sm text-text-basic !h-[44px] min-h-0 shrink-0 justify-start rounded-md px-2 py-0 font-normal';
 
 interface Props {
-  myProfile: Profile;
+  myProfile: MyProfile;
   onLogout: () => void;
 }
 

--- a/features/profile/components/my-profile-share-section.tsx
+++ b/features/profile/components/my-profile-share-section.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import type { Profile } from '../profile.types';
+import type { PublicProfile } from '../profile.types';
 
 import { useProfileShare } from '../profile.hooks';
 import { ProfileShareActions } from './profile-share-actions';
 import { ProfileSummary } from './profile-summary';
 
 interface Props {
-  profile: Profile;
+  profile: PublicProfile;
 }
 
 export const MyProfileShareSection = ({ profile }: Props) => {

--- a/features/profile/components/my-profile-share-section.tsx
+++ b/features/profile/components/my-profile-share-section.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export const MyProfileShareSection = ({ profile }: Props) => {
   const { isShareTooltipOpen, shareTooltipMessage, closeShareTooltip, shareProfile } = useProfileShare({
-    userId: profile.userId,
+    userLink: profile.userLink,
     userName: profile.username,
   });
 

--- a/features/profile/components/mypage-basic-info-section.tsx
+++ b/features/profile/components/mypage-basic-info-section.tsx
@@ -9,7 +9,7 @@ import { Input } from '@/shared/components/input';
 import { Textarea } from '@/shared/components/textarea';
 import { useBooleanState } from '@/shared/hooks/use-boolean-state';
 
-import type { Profile } from '../profile.types';
+import type { MyProfile } from '../profile.types';
 
 import { PROFILE_BIO_MAX_LENGTH } from '../profile.constants';
 import { useUpdateProfile } from '../profile.hooks';
@@ -18,7 +18,7 @@ import { MypageInfoRow } from './mypage-info-row';
 import { ProfileAvatar } from './profile-avatar';
 
 interface Props {
-  profile: Profile;
+  profile: MyProfile;
 }
 
 const IMAGE_GUIDE_TEXT = '□ JPG, JPEG, PNG 형식\n□ 최소 100 x 100px';

--- a/features/profile/components/profile-by-id-section-entry.tsx
+++ b/features/profile/components/profile-by-id-section-entry.tsx
@@ -7,21 +7,21 @@ import { fetchProfileById } from '../profile.api';
 import { ProfileByIdSectionGate } from './profile-by-id-section-gate';
 
 interface Props {
-  userId: number;
+  userLink: string;
   isMyProfile?: boolean;
 }
 
-export const ProfileByIdSectionEntry = async ({ userId, isMyProfile }: Props) => {
+export const ProfileByIdSectionEntry = async ({ userLink, isMyProfile }: Props) => {
   const queryClient = getQueryClient();
 
   await queryClient.prefetchQuery({
-    queryKey: profileKeys.detail(userId),
-    queryFn: () => fetchProfileById(userId),
+    queryKey: profileKeys.detail(userLink),
+    queryFn: () => fetchProfileById(userLink),
   });
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <ProfileByIdSectionGate userId={userId} isMyProfile={isMyProfile} />
+      <ProfileByIdSectionGate userLink={userLink} isMyProfile={isMyProfile} />
     </HydrationBoundary>
   );
 };

--- a/features/profile/components/profile-by-id-section-gate.tsx
+++ b/features/profile/components/profile-by-id-section-gate.tsx
@@ -10,11 +10,11 @@ import { ProfileByIdSection } from './profile-by-id-section';
 import { ProfileSectionLoading } from './profile-section-loading';
 
 interface Props {
-  userId: number;
+  userLink: string;
   isMyProfile?: boolean;
 }
 
-export const ProfileByIdSectionGate = ({ userId, isMyProfile }: Props) => {
+export const ProfileByIdSectionGate = ({ userLink, isMyProfile }: Props) => {
   const { reset } = useQueryErrorResetBoundary();
 
   return (
@@ -31,7 +31,7 @@ export const ProfileByIdSectionGate = ({ userId, isMyProfile }: Props) => {
       )}
     >
       <Suspense fallback={<ProfileSectionLoading />}>
-        <ProfileByIdSection userId={userId} isMyProfile={isMyProfile} />
+        <ProfileByIdSection userLink={userLink} isMyProfile={isMyProfile} />
       </Suspense>
     </ErrorBoundary>
   );

--- a/features/profile/components/profile-by-id-section.tsx
+++ b/features/profile/components/profile-by-id-section.tsx
@@ -5,14 +5,14 @@ import { MyProfileShareSection } from './my-profile-share-section';
 import { ProfileSummary } from './profile-summary';
 
 interface Props {
-  userId: number;
+  userLink: string;
   isMyProfile?: boolean;
 }
 
-export const ProfileByIdSection = ({ userId, isMyProfile: isMyProfileProp }: Props) => {
-  const isMyProfileFromQuery = useIsMyProfile(userId);
+export const ProfileByIdSection = ({ userLink, isMyProfile: isMyProfileProp }: Props) => {
+  const isMyProfileFromQuery = useIsMyProfile(userLink);
   const isMyProfile = isMyProfileProp ?? isMyProfileFromQuery;
-  const { data: profile } = useProfileById(userId);
+  const { data: profile } = useProfileById(userLink);
 
   return isMyProfile ? <MyProfileShareSection profile={profile} /> : <ProfileSummary profile={profile} />;
 };

--- a/features/profile/components/profile-edit-form.tsx
+++ b/features/profile/components/profile-edit-form.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/shared/components/button';
 import { TextField } from '@/shared/components/text-field';
 import { TextareaField } from '@/shared/components/textarea-field';
 
-import type { Profile, UpdateProfilePayload } from '../profile.types';
+import type { MyProfile, UpdateProfilePayload } from '../profile.types';
 
 import { PROFILE_BIO_MAX_LENGTH, PROFILE_NICKNAME_MAX_LENGTH } from '../profile.constants';
 import { ProfileAvatar } from './profile-avatar';
@@ -20,7 +20,7 @@ import { useProfileEditForm } from '../profile.hooks';
 const PROFILE_IMAGE_ACCEPT = 'image/png,image/jpeg,image/webp';
 
 interface Props {
-  profile: Profile;
+  profile: MyProfile;
   isSubmitting: boolean;
   onCancel: () => void;
   onSubmitProfile: (payload: UpdateProfilePayload) => Promise<void>;

--- a/features/profile/components/profile-summary.tsx
+++ b/features/profile/components/profile-summary.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode } from 'react';
 
-import type { Profile } from '../profile.types';
+import type { PublicProfile } from '../profile.types';
 
 import { ProfileAvatar } from './profile-avatar';
 
 interface Props {
-  profile: Profile;
+  profile: PublicProfile;
   shareActions?: ReactNode;
 }
 

--- a/features/profile/index.ts
+++ b/features/profile/index.ts
@@ -9,4 +9,4 @@ export { ProfileDetailView } from './components/profile-detail-view';
 export { ProfileSectionLoading } from './components/profile-section-loading';
 export { buildProfileShareMetadata, buildReviewRequestDescription } from './profile.lib';
 export { profileKeys } from './profile.query-keys';
-export type { Profile, UpdateProfilePayload } from './profile.types';
+export type { MyProfile, PublicProfile, UpdateProfilePayload } from './profile.types';

--- a/features/profile/profile.api.ts
+++ b/features/profile/profile.api.ts
@@ -1,18 +1,18 @@
 import { ApiError, apiRequest } from '@/shared/lib/api';
 import type { ApiRequestOptions } from '@/shared/lib/api';
 
-import type { Profile, UpdateProfilePayload, UpdateProfileResponse } from './profile.types';
+import type { MyProfile, PublicProfile, UpdateProfilePayload, UpdateProfileResponse } from './profile.types';
 
 /** 미로그인·인증 실패 시 API가 반환하는 HTTP status (guest → `null`) */
 const UNAUTHENTICATED_STATUSES = new Set([401, 403]);
 
-export const fetchMyProfile = (init?: ApiRequestOptions): Promise<Profile> => apiRequest('/users/profile', init);
+export const fetchMyProfile = (init?: ApiRequestOptions): Promise<MyProfile> => apiRequest('/users/profile', init);
 
 /**
  * 내 프로필 조회. 미로그인(401/403)은 에러 대신 `null`을 반환한다.
  * SSR prefetch·useSuspenseQuery에서 guest/session 만료를 안전하게 처리하기 위함.
  */
-export const fetchMyProfileOptional = async (init?: ApiRequestOptions): Promise<Profile | null> => {
+export const fetchMyProfileOptional = async (init?: ApiRequestOptions): Promise<MyProfile | null> => {
   try {
     return await fetchMyProfile(init);
   } catch (error) {
@@ -23,8 +23,8 @@ export const fetchMyProfileOptional = async (init?: ApiRequestOptions): Promise<
   }
 };
 
-export const fetchProfileById = (userId: number, init?: ApiRequestOptions): Promise<Profile> =>
-  apiRequest<Profile>(`/users/profile/${userId}`, init);
+export const fetchProfileById = (userId: number, init?: ApiRequestOptions): Promise<PublicProfile> =>
+  apiRequest<PublicProfile>(`/users/profile/${userId}`, init);
 
 const createUpdateProfileFormData = ({ info, profileImage }: UpdateProfilePayload) => {
   const formData = new FormData();

--- a/features/profile/profile.api.ts
+++ b/features/profile/profile.api.ts
@@ -23,8 +23,8 @@ export const fetchMyProfileOptional = async (init?: ApiRequestOptions): Promise<
   }
 };
 
-export const fetchProfileById = (userId: number, init?: ApiRequestOptions): Promise<PublicProfile> =>
-  apiRequest<PublicProfile>(`/users/profile/${userId}`, init);
+export const fetchProfileById = (userLink: string, init?: ApiRequestOptions): Promise<PublicProfile> =>
+  apiRequest<PublicProfile>(`/users/profile/${userLink}`, init);
 
 const createUpdateProfileFormData = ({ info, profileImage }: UpdateProfilePayload) => {
   const formData = new FormData();

--- a/features/profile/profile.hooks.ts
+++ b/features/profile/profile.hooks.ts
@@ -9,7 +9,7 @@ import { useBooleanState } from '@/shared/hooks/use-boolean-state';
 import { useCopyLinkFeedback } from '@/shared/hooks/use-copy-link-feedback';
 import { ApiError } from '@/shared/lib/api';
 
-import type { Profile, UpdateProfilePayload } from './profile.types';
+import type { MyProfile, UpdateProfilePayload } from './profile.types';
 import type { z } from 'zod';
 
 import { fetchMyProfileOptional, fetchProfileById, updateProfile } from './profile.api';
@@ -56,7 +56,7 @@ export const useIsMyProfile = (userId: number) => {
 export type ProfileEditFormData = z.infer<typeof ProfileEditFormSchema>;
 
 interface UseProfileEditFormParams {
-  profile: Profile;
+  profile: MyProfile;
   onSubmitProfile: (payload: UpdateProfilePayload) => Promise<void>;
 }
 

--- a/features/profile/profile.hooks.ts
+++ b/features/profile/profile.hooks.ts
@@ -24,10 +24,10 @@ export const useMyProfile = () => {
   });
 };
 
-export const useProfileById = (userId: number) =>
+export const useProfileById = (userLink: string) =>
   useSuspenseQuery({
-    queryKey: profileKeys.detail(userId),
-    queryFn: () => fetchProfileById(userId),
+    queryKey: profileKeys.detail(userLink),
+    queryFn: () => fetchProfileById(userLink),
   });
 
 export const useUpdateProfile = () => {
@@ -36,7 +36,7 @@ export const useUpdateProfile = () => {
   return useMutation({
     mutationFn: updateProfile,
     onSuccess: (profile) => {
-      queryClient.setQueryData(profileKeys.detail(profile.userId), profile);
+      queryClient.setQueryData(profileKeys.detail(profile.userLink), profile);
       queryClient.setQueryData(profileKeys.my, profile);
     },
   });
@@ -45,12 +45,12 @@ export const useUpdateProfile = () => {
 /**
  * 조회 중인 프로필이 현재 로그인한 사용자의 프로필인지 확인한다.
  *
- * @param userId - 비교할 프로필 사용자 ID
+ * @param userLink - 비교할 프로필 사용자 링크
  * @returns 현재 로그인한 사용자의 프로필이면 `true`, 아니면 `false`
  */
-export const useIsMyProfile = (userId: number) => {
+export const useIsMyProfile = (userLink: string) => {
   const { data: myProfile } = useMyProfile();
-  return myProfile?.userId === userId;
+  return myProfile?.userLink === userLink;
 };
 
 export type ProfileEditFormData = z.infer<typeof ProfileEditFormSchema>;
@@ -150,11 +150,11 @@ export const useProfileEditing = () => {
 };
 
 interface UseProfileShareParams {
-  userId: number;
+  userLink: string;
   userName?: string;
 }
 
-export const useProfileShare = ({ userId, userName }: UseProfileShareParams) => {
+export const useProfileShare = ({ userLink, userName }: UseProfileShareParams) => {
   const {
     open: isShareTooltipOpen,
     message: shareTooltipMessage,
@@ -163,8 +163,8 @@ export const useProfileShare = ({ userId, userName }: UseProfileShareParams) => 
   } = useCopyLinkFeedback();
 
   const shareProfile = useCallback(async () => {
-    await copyLink(buildProfileShareClipboardText(userId, userName));
-  }, [copyLink, userId, userName]);
+    await copyLink(buildProfileShareClipboardText(userLink, userName));
+  }, [copyLink, userLink, userName]);
 
   return {
     isShareTooltipOpen,

--- a/features/profile/profile.hooks.ts
+++ b/features/profile/profile.hooks.ts
@@ -9,8 +9,12 @@ import { useBooleanState } from '@/shared/hooks/use-boolean-state';
 import { useCopyLinkFeedback } from '@/shared/hooks/use-copy-link-feedback';
 import { ApiError } from '@/shared/lib/api';
 
-import type { MyProfile, UpdateProfilePayload } from './profile.types';
-import type { z } from 'zod';
+import type {
+  ProfileEditFormData,
+  UpdateProfilePayload,
+  UseProfileEditFormParams,
+  UseProfileShareParams,
+} from './profile.types';
 
 import { fetchMyProfileOptional, fetchProfileById, updateProfile } from './profile.api';
 import { buildProfileShareClipboardText } from './profile.lib';
@@ -52,13 +56,6 @@ export const useIsMyProfile = (userLink: string) => {
   const { data: myProfile } = useMyProfile();
   return myProfile?.userLink === userLink;
 };
-
-export type ProfileEditFormData = z.infer<typeof ProfileEditFormSchema>;
-
-interface UseProfileEditFormParams {
-  profile: MyProfile;
-  onSubmitProfile: (payload: UpdateProfilePayload) => Promise<void>;
-}
 
 export const useProfileEditForm = ({ profile, onSubmitProfile }: UseProfileEditFormParams) => {
   const [previewImageUrl, setPreviewImageUrl] = useState<string | null>(null);
@@ -148,11 +145,6 @@ export const useProfileEditing = () => {
     submitProfile,
   };
 };
-
-interface UseProfileShareParams {
-  userLink: string;
-  userName?: string;
-}
 
 export const useProfileShare = ({ userLink, userName }: UseProfileShareParams) => {
   const {

--- a/features/profile/profile.lib.ts
+++ b/features/profile/profile.lib.ts
@@ -17,8 +17,8 @@ export const buildReviewRequestDescription = (userName: string): string => {
   return `${displayName}님이 후기 작성을 요청했습니다`;
 };
 
-export const buildProfileShareUrl = (userId: number, userName?: string): string => {
-  const path = ROUTES.PROFILE(userId);
+export const buildProfileShareUrl = (userLink: string, userName?: string): string => {
+  const path = ROUTES.PROFILE(userLink);
   const searchParams = new URLSearchParams();
 
   const trimmedName = userName?.trim();
@@ -37,13 +37,13 @@ export const buildProfileShareUrl = (userId: number, userName?: string): string 
  * 카카오톡 등 채팅 앱 링크 미리보기는 URL의 Open Graph 메타(제목·설명)로 표시됩니다.
  * OG 크롤러는 인증 쿠키가 없으므로 프로필 소유자 이름을 쿼리에 포함합니다.
  */
-export const buildProfileShareClipboardText = (userId: number, userName?: string): string =>
-  buildProfileShareUrl(userId, userName);
+export const buildProfileShareClipboardText = (userLink: string, userName?: string): string =>
+  buildProfileShareUrl(userLink, userName);
 
-export const buildProfileShareMetadata = (userId: number, userName?: string, path?: string): Metadata => {
+export const buildProfileShareMetadata = (userLink: string, userName?: string, path?: string): Metadata => {
   const displayName = userName?.trim() || '회원';
   const description = buildProfileShareDescription(displayName);
-  const profilePath = path ?? `/profile/${userId}`;
+  const profilePath = path ?? `/profile/${userLink}`;
 
   return buildShareOgMetadata({
     description,

--- a/features/profile/profile.query-keys.ts
+++ b/features/profile/profile.query-keys.ts
@@ -1,5 +1,5 @@
 export const profileKeys = {
   all: ['profile'] as const,
   my: ['myProfile'] as const,
-  detail: (userId: number) => [...profileKeys.all, userId] as const,
+  detail: (userLink: string) => [...profileKeys.all, userLink] as const,
 };

--- a/features/profile/profile.types.ts
+++ b/features/profile/profile.types.ts
@@ -1,11 +1,25 @@
-export interface Profile {
+import type { PositionValue, UserLinkType } from '@/features/auth';
+
+export interface ProfileLink {
+  linkId: number;
+  userLinkType: UserLinkType;
+  userLink: string;
+}
+
+/** GET /users/profile/{userLink} 응답 — 누구나 조회 가능한 공개 프로필 정보 */
+export interface PublicProfile {
   userId: number;
   userLink: string;
   username: string;
-  nickname: string;
-  email: string;
   bio: string | null;
   profileImageUrl: string | null;
+  defaultPositions: PositionValue[];
+  links: ProfileLink[];
+}
+
+/** GET /users/profile 응답 — 본인만 조회 가능, 공개 정보에 계정 정보가 더해진다 */
+export interface MyProfile extends PublicProfile {
+  email: string;
   userType: string;
   marketingAgree: boolean;
 }
@@ -21,4 +35,4 @@ export interface UpdateProfilePayload {
   profileImage?: File | null;
 }
 
-export type UpdateProfileResponse = Profile;
+export type UpdateProfileResponse = MyProfile;

--- a/features/profile/profile.types.ts
+++ b/features/profile/profile.types.ts
@@ -1,5 +1,8 @@
 import type { PositionValue, UserLinkType } from '@/features/auth';
 
+import type { ProfileEditFormSchema } from './profile.schemas';
+import type { z } from 'zod';
+
 export interface ProfileLink {
   linkId: number;
   userLinkType: UserLinkType;
@@ -36,3 +39,15 @@ export interface UpdateProfilePayload {
 }
 
 export type UpdateProfileResponse = MyProfile;
+
+export type ProfileEditFormData = z.infer<typeof ProfileEditFormSchema>;
+
+export interface UseProfileEditFormParams {
+  profile: MyProfile;
+  onSubmitProfile: (payload: UpdateProfilePayload) => Promise<void>;
+}
+
+export interface UseProfileShareParams {
+  userLink: string;
+  userName?: string;
+}

--- a/features/project/components/project-section-stream.tsx
+++ b/features/project/components/project-section-stream.tsx
@@ -5,7 +5,12 @@ import { getQueryClient } from '@/shared/lib/get-query-client';
 import { ProjectSection } from './project-section';
 import { fetchUserProjects, projectKeys } from '../project.api';
 
-export const ProjectSectionStream = async ({ userId }: { userId: number }) => {
+interface Props {
+  userId: number;
+  userLink: string;
+}
+
+export const ProjectSectionStream = async ({ userId, userLink }: Props) => {
   const queryClient = getQueryClient();
 
   await queryClient.prefetchQuery({
@@ -15,7 +20,7 @@ export const ProjectSectionStream = async ({ userId }: { userId: number }) => {
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <ProjectSection userId={userId} />
+      <ProjectSection userId={userId} userLink={userLink} />
     </HydrationBoundary>
   );
 };

--- a/features/project/components/project-section.tsx
+++ b/features/project/components/project-section.tsx
@@ -21,14 +21,14 @@ const INITIAL_COUNT = 8;
 const DEFAULT_IMAGE_PATH = '/default.png';
 
 interface ProjectItemProps {
-  userId: number;
+  userLink: string;
   project: UserProjectResponse;
 }
 
-const ProjectItem = ({ userId, project }: ProjectItemProps) => {
+const ProjectItem = ({ userLink, project }: ProjectItemProps) => {
   return (
     <Link
-      href={ROUTES.PROJECT(userId, project.projectId)}
+      href={ROUTES.PROJECT(userLink, project.projectId)}
       className="focus-visible:ring-border-secondary block rounded-lg focus-visible:ring-2 focus-visible:ring-offset-4 focus-visible:outline-none"
     >
       <article className="flex flex-col gap-4 pb-4">
@@ -54,6 +54,7 @@ const ProjectItem = ({ userId, project }: ProjectItemProps) => {
 
 interface ProjectSectionProps {
   userId: number;
+  userLink: string;
 }
 
 const sortProjects = (projects: UserProjectResponse[], sortOrder: SortOrder) =>
@@ -61,7 +62,7 @@ const sortProjects = (projects: UserProjectResponse[], sortOrder: SortOrder) =>
     sortOrder === 'latest' ? b.startDate.localeCompare(a.startDate) : a.startDate.localeCompare(b.startDate),
   );
 
-export const ProjectSection = ({ userId }: ProjectSectionProps) => {
+export const ProjectSection = ({ userId, userLink }: ProjectSectionProps) => {
   const { data: projects, isPending, isError } = useUserProjects(userId);
   const [showAll, setShowAll] = useState(false);
   const [selectedSort, setSelectedSort] = useState<SortOrder>('latest');
@@ -113,7 +114,7 @@ export const ProjectSection = ({ userId }: ProjectSectionProps) => {
         <ul className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
           {visibleProjects.map((project) => (
             <li key={project.projectId}>
-              <ProjectItem userId={userId} project={project} />
+              <ProjectItem userLink={userLink} project={project} />
             </li>
           ))}
         </ul>

--- a/shared/constants/routes.ts
+++ b/shared/constants/routes.ts
@@ -7,7 +7,7 @@ export const ROUTES = {
   MY_SOSS: '/my-soss',
   PRIVACY_POLICY: '/policies/privacy-policy',
   PROFILE_EXAMPLES: '/profile-examples',
-  PROFILE: (userId: string | number) => `/profile/${userId}`,
-  PROJECT: (userId: string | number, projectId: string | number) => `/profile/${userId}/project/${projectId}`,
+  PROFILE: (userLink: string) => `/profile/${userLink}`,
+  PROJECT: (userLink: string, projectId: string | number) => `/profile/${userLink}/project/${projectId}`,
   TERMS_OF_SERVICE: '/policies/terms-of-service',
 } as const;


### PR DESCRIPTION
# 📝 개요

Swagger 문서 기준으로 `features/profile`의 응답 타입을 다시 정의하고, `GET /users/profile/{userLink}`가 실제로는 문자열 `userLink`를 받는데 숫자 `userId`로 호출하던 문제를 수정했다.

## 🔗 관련 이슈

- Closes #282

## 🛠️ 변경 사항 (Checklist)

- [x] 🐞 Bug: `fetchProfileById`가 `userId`를 넘겨 실제 엔드포인트(`/users/profile/{userLink}`)와 맞지 않던 문제 수정
- [x] ♻️ Refactor: 존재하지 않는 필드가 섞여 있던 `Profile` 타입을 실제 API 응답 기준 `PublicProfile`/`MyProfile`로 분리, `profile.hooks.ts`에 있던 타입 정의를 `profile.types.ts`로 이동

### 커밋 구성

1. `refactor: profile 응답 타입을 MyProfile/PublicProfile로 분리` — 공개 조회(`GET /users/profile/{userLink}`)와 본인 조회(`GET /users/profile`) 응답 스키마 차이를 타입으로 반영
2. `fix: fetchProfileById를 userLink 기준으로 조회하도록 수정` — 라우트(`app/(protected)/profile/[userId]` → `[userLink]`)·쿼리키·공유 링크 빌더·project 도메인 링크 생성까지 일관되게 수정
3. `refactor: profile 훅에 있던 타입 정의를 types 파일로 이동` — `folder-architecture.md`의 파일 위치 규칙 준수

## ✅ 아래 내용을 한 번 더 점검해 주세요

### 1. 의도와 가독성 (Naming & Readability)

- [x] **의도 중심 네이밍**: `Profile` → `PublicProfile`/`MyProfile`로 분리해 어떤 응답인지 이름만으로 드러나도록 함
- [x] **선언적 코드**: 확인함
- [x] **주석**: 각 타입 위에 대응하는 API 엔드포인트만 짧게 명시

### 2. 타입과 논리 (Type Safety & Logic)

- [x] **타입 안전성**: `any` 미사용, 반환 타입 명시
- [x] **엣지 케이스**: 확인함
- [x] **하드코딩 방지**: 해당 없음

### 3. 코드 다이어트 (Clean-up)

- [x] **찌꺼기 제거**: 사용되지 않던 `nickname` 필드 제거
- [x] **불필요한 코드**: 확인함
- [x] **Linter**: `tsc --noEmit`, `eslint` 통과 확인

### 4. 지속 가능성 (Sustainability)

- [ ] **테스트**: 타입체크/린트만 확인, 실제 브라우저 동작 미검증 — 리뷰 시 실제 프로필 페이지 접근 확인 필요
- [x] **문서화**: 해당 없음

## 💭 회고 (Optional)

- `app/(public)/profile-examples`의 `DEMO_PROFILE_USER_LINK` 값은 실제 백엔드 데모 계정의 `userLink`를 몰라 기존 숫자값(`'1'`)을 문자열로 임시 대체함. 배포 전 실제 값 확인 필요.