### PR TITLE
fix: auth API/스키마를 백엔드 스펙에 맞게 정비

### DIFF
--- a/features/auth/auth.api.ts
+++ b/features/auth/auth.api.ts
@@ -51,6 +51,20 @@ export const deleteAccount = async (payload: DeleteAccountPayload): Promise<void
   await apiRequest('/users', { method: 'DELETE', body: payload });
 };
 
+// 백엔드 로그아웃(서버측 refreshToken 무효화). 실패해도 로컬 로그아웃은 진행되어야 하므로 throw하지 않고 ok 반환.
+// landing-header(클라이언트)에서만 호출되므로 Next 프록시 rewrite를 타는 상대경로 + same-origin으로 refreshToken 쿠키를 전달한다.
+export const logout = async (): Promise<boolean> => {
+  try {
+    const res = await fetch('/api/v1/login/logout', {
+      method: 'POST',
+      credentials: 'same-origin',
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+};
+
 // 인가코드 → 세션 쿠키 교환. 실패 시 ok:false (route가 '/'로 리다이렉트)
 export const exchangeKakaoCode = async (code: string): Promise<KakaoLoginResult> => {
   const res = await fetch(`${KAKAO_API_BASE}/api/v1/login/kakao?code=${encodeURIComponent(code)}`);

--- a/features/auth/auth.hooks.ts
+++ b/features/auth/auth.hooks.ts
@@ -134,11 +134,11 @@ export const useSignupFlow = () => {
 };
 
 const toDeleteAccountPayload = (data: AccountDeletionFormData): DeleteAccountPayload => {
-  const detail = data.reason === 'other' ? data.detail?.trim() : undefined;
+  const detail = data.reason === 'other' ? (data.detail?.trim() ?? null) : null;
 
   return {
     userDeleteReasonEnum: WITHDRAW_REASON_ENUM_MAP[data.reason],
-    ...(detail ? { detail } : {}),
+    detail,
   };
 };
 

--- a/features/auth/auth.types.ts
+++ b/features/auth/auth.types.ts
@@ -13,7 +13,7 @@ export type AccountDeletionFormData = z.infer<typeof AccountDeletionFormSchema>;
 
 export interface DeleteAccountPayload {
   userDeleteReasonEnum: string;
-  detail?: string;
+  detail: string | null;
 }
 
 export type PositionValue = (typeof POSITION_VALUES)[number];
@@ -48,6 +48,7 @@ export interface SignupResponse {
   defaultPositions: string[];
   links: SignupResponseLink[];
   marketingAgree: boolean;
+  userLink: string;
 }
 
 export interface KakaoLoginResult {

--- a/features/auth/components/landing-header.tsx
+++ b/features/auth/components/landing-header.tsx
@@ -11,6 +11,7 @@ import { HeaderLogoLink } from '@/shared/components/header/header-logo-link';
 import { ROUTES } from '@/shared/constants/routes';
 import { cn } from '@/shared/lib/cn';
 
+import { logout } from '../auth.api';
 import { LoginButton } from './login-button';
 
 const actionButtonClassName = 'h-10 min-w-[68px] shrink-0 rounded-md px-5 py-0';
@@ -36,6 +37,8 @@ const LandingHeaderInner = () => {
 
   const handleLogout = async () => {
     setHasLoggedOut(true);
+    // 백엔드 refreshToken 무효화(실패해도 로컬 로그아웃은 계속 진행)
+    await logout();
     await fetch('/api/logout', { method: 'POST' });
     queryClient.clear();
     router.push(ROUTES.HOME);

--- a/features/auth/index.ts
+++ b/features/auth/index.ts
@@ -1,4 +1,4 @@
-export { exchangeKakaoCode, fetchNeedsOnboarding } from './auth.api';
+export { exchangeKakaoCode, fetchNeedsOnboarding, logout } from './auth.api';
 export { LOGIN_RETURN_COOKIE_NAME, USER_LINK_TYPE_OPTIONS, USER_LINKS_MAX } from './auth.constants';
 export type { PositionValue, UserLinkType } from './auth.types';
 export { useLoginGate } from './login-modal.hooks';


### PR DESCRIPTION
# 📝 개요

`features/auth/`의 API/타입을 백엔드 Swagger 스펙(auth.md)에 맞게 정비했습니다.

- `SignupResponse`에 최상위 `userLink` 필드 추가
- 백엔드 로그아웃(`POST /api/v1/login/logout`, refreshToken 무효화)을 호출하는 `logout()` 추가, 로그아웃 시 로컬 쿠키 삭제 전에 호출
- 회원 탈퇴 payload의 `detail`을 조건부 생략 대신 항상 전송(non-other는 `null`)하도록 수정
- `reissue`는 `shared/lib/api/client.ts`에 이미 구현되어 있어 중복 추가하지 않음

## 🔗 관련 이슈

- Closes #284

## 🛠️ 변경 사항 (Checklist)

- [ ] ✨ Feature: 새로운 기능 추가
- [x] 🚀 Enhancement: 기존 기능 개선/성능 향상
- [x] 🐞 Bug: 버그 수정
- [ ] ♻️ Refactor: 코드 구조 개선 (기능 변화 없음)
- [ ] 🏗️ Chore: 빌드/패키지 설정/단순 잡일
- [ ] 🎨 Design: UI/UX 스타일 수정
- [ ] 📚 Documentation: 문서 수정

## ✅ 아래 내용을 한 번 더 점검해 주세요

### 1. 의도와 가독성 (Naming & Readability)

- [x] **의도 중심 네이밍**: 변수명에서 '역할'이, 함수명에서 '행위+대상'이 명확히 드러나나요?
- [x] **선언적 코드**: '어떻게'가 아닌 '무엇을' 하는지 코드만 보고도 알 수 있나요?
- [x] **주석**: 코드만으로 설명이 어려운 '특정 로직'에만 주석을 달았나요?

### 2. 타입과 논리 (Type Safety & Logic)

- [x] **타입 안전성**: `any` 사용을 지양하고, 모든 함수의 반환 타입을 명시했나요?
- [x] **엣지 케이스**: 데이터가 없거나(`null/undefined`), 에러가 발생할 경우를 처리했나요?
- [x] **하드코딩 방지**: API 주소나 설정값들이 환경 변수나 상수로 분리되었나요?

### 3. 코드 다이어트 (Clean-up)

- [x] **찌꺼기 제거**: 디버깅용 `console.log`나 사용하지 않는 `import`를 모두 지웠나요?
- [x] **불필요한 코드**: 죽은 코드(Dead Code)는 없나요?
- [x] **Linter**: 린트 에러나 워닝이 남아있지 않나요?

### 4. 지속 가능성 (Sustainability)

- [x] **테스트**: 수동으로든 코드로든 정상 작동을 확인했나요? (lint/build 통과 확인, 로그아웃은 브라우저 수동 테스트 권장)
- [ ] **문서화**: 새로운 환경 변수나 라이브러리가 추가되어 README 업데이트가 필요한가요?