### PR TITLE
feat: 프로필 상세 탭 상태를 URL 쿼리 파라미터와 동기화

### DIFF
--- a/features/profile/components/profile-detail-view.tsx
+++ b/features/profile/components/profile-detail-view.tsx
@@ -2,7 +2,11 @@
 
 import type { ReactNode } from 'react';
 
+import { Suspense } from 'react';
+
 import { Tab } from '@/shared/components/tab';
+
+import { useProfileDetailTab } from '../profile.hooks';
 
 interface Props {
   userId: number;
@@ -10,8 +14,33 @@ interface Props {
   projectsTabContent: ReactNode;
 }
 
-export const ProfileDetailView = ({ userId, allTabContent, projectsTabContent }: Props) => (
-  <Tab.Root key={userId} defaultValue="all">
+// useSearchParams를 쓰는 useProfileDetailTab을 Suspense로 감싸지 않으면
+// 정적 분석 시 서버가 빈 검색 파라미터로 렌더링해 하이드레이션이 어긋난다.
+export const ProfileDetailView = (props: Props) => (
+  <Suspense fallback={<ProfileDetailTabs {...props} value="all" onValueChange={() => {}} />}>
+    <ProfileDetailTabsWithUrlSync {...props} />
+  </Suspense>
+);
+
+const ProfileDetailTabsWithUrlSync = (props: Props) => {
+  const { value, onValueChange } = useProfileDetailTab();
+
+  return <ProfileDetailTabs {...props} value={value} onValueChange={onValueChange} />;
+};
+
+interface ProfileDetailTabsProps extends Props {
+  value: string;
+  onValueChange: (value: string) => void;
+}
+
+const ProfileDetailTabs = ({
+  userId,
+  allTabContent,
+  projectsTabContent,
+  value,
+  onValueChange,
+}: ProfileDetailTabsProps) => (
+  <Tab.Root key={userId} value={value} onValueChange={onValueChange}>
     <Tab.List aria-label="프로필 정보 탭" className="w-full gap-0">
       <Tab.Trigger value="all" className="flex-1">
         전체

--- a/features/profile/profile.constants.ts
+++ b/features/profile/profile.constants.ts
@@ -3,3 +3,19 @@ export const PROFILE_NICKNAME_MAX_LENGTH = 20;
 
 /** 한 줄 소개 최대 글자 수 — 스키마 검증과 입력 필드 maxLength에서 공유 */
 export const PROFILE_BIO_MAX_LENGTH = 50;
+
+/** 프로필 상세 탭 상태를 담는 URL query parameter key */
+export const PROFILE_DETAIL_TAB_QUERY_KEY = 'tab';
+
+/** 프로필 상세 탭의 유효한 값 목록 */
+export const PROFILE_DETAIL_TABS = ['all', 'projects'] as const;
+
+/** 프로필 상세 탭 값 타입 */
+export type ProfileDetailTab = (typeof PROFILE_DETAIL_TABS)[number];
+
+/** 프로필 상세 기본 탭 */
+export const DEFAULT_PROFILE_DETAIL_TAB: ProfileDetailTab = 'all';
+
+/** 주어진 값이 유효한 프로필 상세 탭 값인지 확인한다. */
+export const isProfileDetailTab = (value: string | null): value is ProfileDetailTab =>
+  value !== null && PROFILE_DETAIL_TABS.includes(value as ProfileDetailTab);

--- a/features/profile/profile.hooks.ts
+++ b/features/profile/profile.hooks.ts
@@ -2,12 +2,14 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { useBooleanState } from '@/shared/hooks/use-boolean-state';
 import { useCopyLinkFeedback } from '@/shared/hooks/use-copy-link-feedback';
 import { ApiError } from '@/shared/lib/api';
+import { buildPathWithSearch, setSearchParam } from '@/shared/lib/url/search-params';
 
 import type {
   ProfileEditFormData,
@@ -17,6 +19,12 @@ import type {
 } from './profile.types';
 
 import { fetchMyProfileOptional, fetchProfileById, updateProfile } from './profile.api';
+import {
+  DEFAULT_PROFILE_DETAIL_TAB,
+  isProfileDetailTab,
+  PROFILE_DETAIL_TAB_QUERY_KEY,
+  type ProfileDetailTab,
+} from './profile.constants';
 import { buildProfileShareClipboardText } from './profile.lib';
 import { profileKeys } from './profile.query-keys';
 import { ProfileEditFormSchema } from './profile.schemas';
@@ -164,4 +172,32 @@ export const useProfileShare = ({ userLink, userName }: UseProfileShareParams) =
     closeShareTooltip,
     shareProfile,
   };
+};
+
+/**
+ * 프로필 상세 탭 상태를 URL query parameter(`?tab=all|projects`)와 동기화한다.
+ *
+ * 유효하지 않은 값은 기본 탭('all')으로 폴백한다. 탭 전환 시
+ * `window.history.replaceState`로 URL만 갱신해 서버 컴포넌트 리페치와 스크롤
+ * 이동 없이 shallow routing을 수행한다.
+ */
+export const useProfileDetailTab = (): {
+  value: ProfileDetailTab;
+  onValueChange: (next: string) => void;
+} => {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+
+  const raw = searchParams.get(PROFILE_DETAIL_TAB_QUERY_KEY);
+  const value = isProfileDetailTab(raw) ? raw : DEFAULT_PROFILE_DETAIL_TAB;
+
+  const onValueChange = useCallback(
+    (next: string) => {
+      const params = setSearchParam(searchParams, PROFILE_DETAIL_TAB_QUERY_KEY, next);
+      window.history.replaceState(null, '', buildPathWithSearch(pathname, params));
+    },
+    [pathname, searchParams],
+  );
+
+  return { value, onValueChange };
 };

--- a/shared/components/tab.tsx
+++ b/shared/components/tab.tsx
@@ -71,7 +71,7 @@ const TabTrigger = ({ className, ...restProps }: ComponentPropsWithRef<typeof Ta
   return (
     <Tabs.Trigger
       className={cn(
-        'h-10 cursor-pointer text-center transition-colors',
+        'h-16 cursor-pointer text-center transition-colors',
         'text-text-subtle data-[state=active]:text-text-secondary',
         'text-heading-sm px-3 font-bold',
         className,


### PR DESCRIPTION
# 📝 개요

`ProfileDetailView`의 전체/프로젝트별 탭을 비제어(`defaultValue`)에서 `?tab=all|projects` 쿼리 파라미터 기반 controlled 상태로 전환했다.

- `useProfileDetailTab` 훅으로 URL과 탭 상태 동기화
- `window.history.replaceState` 사용 — App Router의 `router.replace`는 동일 경로라도 서버 컴포넌트(RSC) 페이로드를 재요청하므로, 이를 피하고 스크롤도 유지하기 위해 채택
- `useSearchParams()`를 사용하는 부분(`ProfileDetailTabsWithUrlSync`)을 순수 UI 컴포넌트(`ProfileDetailTabs`)와 분리하고 `Suspense`로 감싸, "프로젝트별" 탭으로 새로고침 시 발생하던 하이드레이션 에러를 해결. Suspense 없이 `useSearchParams()`를 호출하면 Next.js가 정적 분석 시 서버 렌더링을 빈 쿼리 기준으로 고정해버려 실제 URL과 클라이언트 하이드레이션이 어긋나는 문제였음

## 🔗 관련 이슈

- Closes #331

## 🛠️ 변경 사항 (Checklist)

- [x] ✨ Feature: 새로운 기능 추가
- [ ] 🚀 Enhancement: 기존 기능 개선/성능 향상
- [ ] 🐞 Bug: 버그 수정
- [ ] ♻️ Refactor: 코드 구조 개선 (기능 변화 없음)
- [ ] 🏗️ Chore: 빌드/패키지 설정/단순 잡일
- [ ] 🎨 Design: UI/UX 스타일 수정
- [ ] 📚 Documentation: 문서 수정

## ✅ 아래 내용을 한 번 더 점검해 주세요

### 1. 의도와 가독성 (Naming & Readability)

- [x] **의도 중심 네이밍**: 변수명에서 '역할'이, 함수명에서 '행위+대상'이 명확히 드러나나요?
- [x] **선언적 코드**: '어떻게'가 아닌 '무엇을' 하는지 코드만 보고도 알 수 있나요?
- [x] **주석**: 코드만으로 설명이 어려운 '특정 로직'에만 주석을 달았나요?

### 2. 타입과 논리 (Type Safety & Logic)

- [x] **타입 안전성**: `any` 사용을 지양하고, 모든 함수의 반환 타입을 명시했나요?
- [x] **엣지 케이스**: 데이터가 없거나(`null/undefined`), 에러가 발생할 경우를 처리했나요?
- [x] **하드코딩 방지**: API 주소나 설정값들이 환경 변수나 상수로 분리되었나요?

### 3. 코드 다이어트 (Clean-up)

- [x] **찌꺼기 제거**: 디버깅용 `console.log`나 사용하지 않는 `import`를 모두 지웠나요?
- [x] **불필요한 코드**: 죽은 코드(Dead Code)는 없나요?
- [x] **Linter**: 린트 에러나 워닝이 남아있지 않나요?

### 4. 지속 가능성 (Sustainability)

- [x] **테스트**: 수동으로든 코드로든 정상 작동을 확인했나요? (하이드레이션 에러 재현 및 해결 확인)
- [ ] **문서화**: 새로운 환경 변수나 라이브러리가 추가되어 README 업데이트가 필요한가요? (신규 의존성 없음)