### PR TITLE
design: 스펙트럼 슬라이더 UI 개선 및 후기 슬라이더와 통일

### DIFF
--- a/features/review/components/write-review/review-spectrum-slider.tsx
+++ b/features/review/components/write-review/review-spectrum-slider.tsx
@@ -4,28 +4,39 @@ import { Fragment } from 'react';
 
 import { cn } from '@/shared/lib/cn';
 
-import { REVIEW_SPECTRUM_STEP_COUNT } from '../../review.constants';
+import { REVIEW_DEFAULT_SPECTRUM_STEP, REVIEW_SPECTRUM_STEP_COUNT } from '../../review.constants';
 
 const MAX_STEP_INDEX = REVIEW_SPECTRUM_STEP_COUNT - 1;
-
-/** 프로필 스펙트럼과 동일한 좌·우 트랙 그라데이션 (skyblue→primary / tertiary→yellow) */
-const LEFT_TRACK_CLASS = 'bg-gradient-to-r from-graphic-skyblue-subtler to-primary-500';
-const RIGHT_TRACK_CLASS = 'bg-gradient-to-r from-tertiary-500 to-yellow-500';
+const CENTER_STEP = REVIEW_DEFAULT_SPECTRUM_STEP;
+const LEFT_TRACK_CLASS = 'bg-gradient-to-r from-primary-500 to-graphic-skyblue-subtler';
+const RIGHT_TRACK_CLASS = 'bg-gradient-to-r from-graphic-yellow to-tertiary-500';
+const TRACK_SEGMENT_KEYS = ['left-3', 'left-2', 'left-1', 'right-1', 'right-2', 'right-3'] as const;
 
 interface Props {
   leftLabel: string;
   rightLabel: string;
-  /** 0 ~ MAX_STEP_INDEX */
+  /** 0 ~ MAX_STEP_INDEX. CENTER_STEP is only used before the user selects a value. */
   value: number;
   onChange: (step: number) => void;
 }
 
 const clampStep = (step: number) => Math.min(MAX_STEP_INDEX, Math.max(0, step));
 
+const skipCenterStep = (step: number, direction: -1 | 1) => {
+  if (step !== CENTER_STEP) {
+    return step;
+  }
+  return CENTER_STEP + direction;
+};
+
+const toSelectableStep = (step: number, direction: -1 | 1) => clampStep(skipCenterStep(clampStep(step), direction));
+
 const stepFromPointer = (element: HTMLElement, clientX: number) => {
   const rect = element.getBoundingClientRect();
   const ratio = rect.width > 0 ? (clientX - rect.left) / rect.width : 0;
-  return clampStep(Math.round(Math.min(1, Math.max(0, ratio)) * MAX_STEP_INDEX));
+  const clampedRatio = Math.min(1, Math.max(0, ratio));
+  const step = Math.round(clampedRatio * MAX_STEP_INDEX);
+  return toSelectableStep(step, clampedRatio < 0.5 ? -1 : 1);
 };
 
 export const ReviewSpectrumSlider = ({ leftLabel, rightLabel, value, onChange }: Props) => {
@@ -55,26 +66,31 @@ export const ReviewSpectrumSlider = ({ leftLabel, rightLabel, value, onChange }:
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     let next = value;
+    let direction: -1 | 1 = 1;
     switch (event.key) {
       case 'ArrowLeft':
       case 'ArrowDown':
         next = value - 1;
+        direction = -1;
         break;
       case 'ArrowRight':
       case 'ArrowUp':
         next = value + 1;
+        direction = 1;
         break;
       case 'Home':
         next = 0;
+        direction = -1;
         break;
       case 'End':
         next = MAX_STEP_INDEX;
+        direction = 1;
         break;
       default:
         return;
     }
     event.preventDefault();
-    const clamped = clampStep(next);
+    const clamped = toSelectableStep(next, direction);
     if (clamped !== value) {
       onChange(clamped);
     }
@@ -89,29 +105,27 @@ export const ReviewSpectrumSlider = ({ leftLabel, rightLabel, value, onChange }:
         tabIndex={0}
         aria-label={`${leftLabel}에서 ${rightLabel} 사이 성향`}
         aria-valuemin={1}
-        aria-valuemax={REVIEW_SPECTRUM_STEP_COUNT}
-        aria-valuenow={value + 1}
+        aria-valuemax={MAX_STEP_INDEX}
+        aria-valuenow={value < CENTER_STEP ? value + 1 : value}
         className="relative flex h-5 w-full cursor-pointer touch-none items-center outline-none select-none"
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
         onKeyDown={handleKeyDown}
       >
-        <div className="relative h-2 w-full">
-          <div
-            aria-hidden
-            className={cn('absolute inset-y-0 left-0 rounded-l-full', LEFT_TRACK_CLASS)}
-            style={{ width: `${percent}%` }}
-          />
-          <div
-            aria-hidden
-            className={cn('absolute inset-y-0 right-0 rounded-r-full', RIGHT_TRACK_CLASS)}
-            style={{ left: `${percent}%` }}
-          />
+        <div className="relative h-2 w-full overflow-hidden rounded-[2px]">
+          <div aria-hidden className={cn('absolute inset-y-0 left-0 w-1/2', LEFT_TRACK_CLASS)} />
+          <div aria-hidden className={cn('absolute inset-y-0 right-0 w-1/2', RIGHT_TRACK_CLASS)} />
+          <div aria-hidden className="absolute inset-0 grid grid-cols-6">
+            {TRACK_SEGMENT_KEYS.map((key, index) => (
+              <span key={key} className={cn(index < MAX_STEP_INDEX - 1 && 'border-input-surface border-r-[0.5px]')} />
+            ))}
+          </div>
         </div>
         <span
           aria-hidden
-          className="border-border-gray-light absolute top-1/2 size-5 -translate-x-1/2 -translate-y-1/2 rounded-full border bg-white shadow-[0_1px_4px_rgba(0,0,0,0.15)] transition-[left] duration-75"
+          className="bg-input-surface absolute top-1/2 size-5 -translate-x-1/2 -translate-y-1/2 rounded-full shadow-[0px_4px_16px_rgba(96,96,96,0.3)] transition-[left] duration-75"
           style={{ left: `${percent}%` }}
         />
       </div>

--- a/features/review/review.constants.ts
+++ b/features/review/review.constants.ts
@@ -10,11 +10,11 @@ export type ReviewStepId = (typeof REVIEW_STEPS)[number]['id'];
 
 export const REVIEW_MAX_TAGS = 3;
 
-/** 스펙트럼 슬라이더 단계 수 (백엔드 강도 1~6에 대응) */
-export const REVIEW_SPECTRUM_STEP_COUNT = 6;
+/** 스펙트럼 슬라이더 핸들 위치 수. 중앙 위치는 초기 중립 상태로만 사용한다. */
+export const REVIEW_SPECTRUM_STEP_COUNT = 7;
 
-/** 스펙트럼 슬라이더 초기 단계 (0~5 중 중앙) */
-export const REVIEW_DEFAULT_SPECTRUM_STEP = 2;
+/** 스펙트럼 슬라이더 초기 단계 (0~6 중 중앙) */
+export const REVIEW_DEFAULT_SPECTRUM_STEP = 3;
 
 export const REVIEW_FEEDBACK_MIN_LENGTH = 10;
 

--- a/features/review/review.hooks.ts
+++ b/features/review/review.hooks.ts
@@ -13,7 +13,7 @@ import type { ReviewStepId } from './review.constants';
 import type { ReviewWriteFormData } from './review.types';
 
 import { createReview, fetchProjectReviews, fetchReviewFormData, fetchReviews, reviewKeys } from './review.api';
-import { REVIEW_DEFAULT_SPECTRUM_STEP, REVIEW_STEPS } from './review.constants';
+import { REVIEW_STEPS } from './review.constants';
 import { spectrumStepToValue } from './review.lib';
 import { ReviewWriteFormSchema } from './review.schemas';
 
@@ -125,7 +125,7 @@ export const useWriteReviewFlow = ({ projectId, revieweeId }: UseWriteReviewFlow
           const answer = formSpectrums.find((item) => item.spectrumId === spectrum.spectrumId);
           return {
             spectrumId: spectrum.spectrumId,
-            value: spectrumStepToValue(answer?.step ?? REVIEW_DEFAULT_SPECTRUM_STEP),
+            value: answer ? spectrumStepToValue(answer.step) : 1,
           };
         });
     try {

--- a/features/review/review.lib.ts
+++ b/features/review/review.lib.ts
@@ -2,8 +2,8 @@ import type { Tag } from '@/features/tag';
 
 import type { Review, ReviewFormData, Spectrum, UserPosition } from './review.types';
 
-/** 스펙트럼 슬라이더 step(0~5) → 백엔드 강도(1~6) */
-export const spectrumStepToValue = (step: number): number => step + 1;
+/** 스펙트럼 슬라이더 step(0~6, 중앙 제외) -> 백엔드 강도(1~6) */
+export const spectrumStepToValue = (step: number): number => (step < 3 ? step + 1 : step);
 
 /** 후기에 표시되는 직군 라벨 */
 export const USER_POSITION_LABELS: Record<UserPosition, string> = {

--- a/features/review/review.schemas.ts
+++ b/features/review/review.schemas.ts
@@ -4,6 +4,7 @@ import {
   REVIEW_FEEDBACK_MAX_LENGTH,
   REVIEW_FEEDBACK_MIN_LENGTH,
   REVIEW_MAX_TAGS,
+  REVIEW_DEFAULT_SPECTRUM_STEP,
   REVIEW_SPECTRUM_STEP_COUNT,
 } from './review.constants';
 
@@ -19,7 +20,8 @@ export const ReviewSpectrumAnswerSchema = z.object({
     .number()
     .int()
     .min(0)
-    .max(REVIEW_SPECTRUM_STEP_COUNT - 1),
+    .max(REVIEW_SPECTRUM_STEP_COUNT - 1)
+    .refine((step) => step !== REVIEW_DEFAULT_SPECTRUM_STEP),
 });
 
 export const ReviewTagIdsSchema = z

--- a/features/spectrum/components/spectrum-average-section.tsx
+++ b/features/spectrum/components/spectrum-average-section.tsx
@@ -1,9 +1,12 @@
+import { cn } from '@/shared/lib/cn';
+
 import type { SpectrumInfo } from '../spectrum.types';
 
 import {
   SPECTRUM_LEFT_TRACK_CLASS,
   SPECTRUM_MARKER_CLASS,
   SPECTRUM_RIGHT_TRACK_CLASS,
+  SPECTRUM_TRACK_SEGMENT_KEYS,
   spectrumAxisLabels,
 } from '../spectrum.constants';
 import { toMarkerLeft } from '../spectrum.lib';
@@ -33,20 +36,22 @@ export const SpectrumAverageSection = ({ spectrumInfo }: Props) => (
           const markerLeft = toMarkerLeft(axis.averageStrength);
 
           return (
-            <div key={axis.axisName} className="relative h-7 min-h-7">
-              <div className="absolute top-1/2 right-0 left-0 h-2 -translate-y-1/2">
-                <div
-                  aria-hidden
-                  className={`absolute top-0 left-0 h-full rounded-l-[2px] ${SPECTRUM_LEFT_TRACK_CLASS}`}
-                  style={{ width: markerLeft }}
-                />
-                <div
-                  aria-hidden
-                  className={`absolute top-0 h-full rounded-r-[2px] ${SPECTRUM_RIGHT_TRACK_CLASS}`}
-                  style={{ left: markerLeft, width: `calc(100% - ${markerLeft})` }}
-                />
-                <div aria-hidden className={SPECTRUM_MARKER_CLASS} style={{ left: markerLeft }} />
+            <div key={axis.axisName} className="relative flex h-7 min-h-7 items-center">
+              <div className="relative h-3 w-full overflow-hidden rounded">
+                <div aria-hidden className={cn('absolute inset-y-0 left-0 w-1/2', SPECTRUM_LEFT_TRACK_CLASS)} />
+                <div aria-hidden className={cn('absolute inset-y-0 right-0 w-1/2', SPECTRUM_RIGHT_TRACK_CLASS)} />
+                <div aria-hidden className="absolute inset-0 grid grid-cols-6">
+                  {SPECTRUM_TRACK_SEGMENT_KEYS.map((key, index) => (
+                    <span
+                      key={key}
+                      className={cn(
+                        index < SPECTRUM_TRACK_SEGMENT_KEYS.length - 1 && 'border-input-surface border-r-[0.5px]',
+                      )}
+                    />
+                  ))}
+                </div>
               </div>
+              <div aria-hidden className={SPECTRUM_MARKER_CLASS} style={{ left: markerLeft }} />
             </div>
           );
         })}

--- a/features/spectrum/spectrum.constants.ts
+++ b/features/spectrum/spectrum.constants.ts
@@ -9,11 +9,14 @@ export const spectrumAxisLabels = [
   { left: '냉철한 결과 지향', right: '따뜻한 관계 지향' },
 ] as const;
 
-/** Figma 4262:76471 — 평균 지표 좌측 트랙 (skyblue-subtler → primary-500) */
-export const SPECTRUM_LEFT_TRACK_CLASS = 'bg-gradient-to-r from-graphic-skyblue-subtler to-primary-500';
+/** 평균 지표 좌측 트랙 (primary-500 → skyblue-subtler). 후기 스펙트럼 슬라이더와 동일. */
+export const SPECTRUM_LEFT_TRACK_CLASS = 'bg-gradient-to-r from-primary-500 to-graphic-skyblue-subtler';
 
-/** Figma 4262:76471 — 평균 지표 우측 트랙 (tertiary-500 → yellow-500) */
-export const SPECTRUM_RIGHT_TRACK_CLASS = 'bg-gradient-to-r from-tertiary-500 to-yellow-500';
+/** 평균 지표 우측 트랙 (graphic-yellow → tertiary-500). 후기 스펙트럼 슬라이더와 동일. */
+export const SPECTRUM_RIGHT_TRACK_CLASS = 'bg-gradient-to-r from-graphic-yellow to-tertiary-500';
+
+/** 평균 지표 트랙 6분할 세그먼트 구분선 key */
+export const SPECTRUM_TRACK_SEGMENT_KEYS = ['left-3', 'left-2', 'left-1', 'right-1', 'right-2', 'right-3'] as const;
 
 /** Figma 4262:76471 — 평가 분포 좌측(왼쪽 성향) 막대 */
 export const DISTRIBUTION_LEFT_BAR_CLASS = 'bg-gradient-to-t from-graphic-skyblue-subtler to-primary-500';
@@ -21,5 +24,6 @@ export const DISTRIBUTION_LEFT_BAR_CLASS = 'bg-gradient-to-t from-graphic-skyblu
 /** Figma 4262:76471 — 평가 분포 우측(오른쪽 성향) 막대 */
 export const DISTRIBUTION_RIGHT_BAR_CLASS = 'bg-gradient-to-b from-tertiary-500 to-yellow-500';
 
+/** 프로필 표시용 핸들. 후기 슬라이더보다 작은 size-4에 흰 배경 + 진한 테두리 링. */
 export const SPECTRUM_MARKER_CLASS =
-  'border-border-gray-dark bg-bg-white absolute top-1/2 z-10 size-2.5 -translate-x-1/2 -translate-y-1/2 rounded-[2px] border';
+  'bg-input-surface border-border-gray-dark absolute top-1/2 z-10 size-4 -translate-x-1/2 -translate-y-1/2 rounded-full border shadow-[0px_2px_6px_rgba(96,96,96,0.24)]';

--- a/features/spectrum/spectrum.lib.ts
+++ b/features/spectrum/spectrum.lib.ts
@@ -64,12 +64,18 @@ export const toDistributionBars = (axes: SpectrumAxisInfo[]): DistributionBar[] 
     ];
   });
 
-const STRENGTH_RANGE = 5;
+/** 스펙트럼 슬라이더 최대 스텝 인덱스(7단계, 후기 슬라이더와 동일). 중앙 스텝 3은 사용하지 않는다. */
+const SPECTRUM_MAX_STEP_INDEX = 6;
 
-/** 평균 강도(1=좌, 6=우)를 마커 CSS `left` 퍼센트로 변환합니다. */
+/**
+ * 평균 강도(1=좌, 6=우)를 7단계 슬라이더의 마커 CSS `left` 퍼센트로 변환합니다.
+ * UI는 0~6 스텝이지만 중앙(3)은 비워두고 나머지 6개 스텝만 사용하므로,
+ * 강도 1~3은 스텝 0~2, 강도 4~6은 스텝 4~6에 대응시켜 6분할 트랙과 정렬합니다.
+ */
 export const toMarkerLeft = (averageStrength: number): string => {
   const strength = normalizeStrength(averageStrength);
-  const percent = ((strength - 1) / STRENGTH_RANGE) * 100;
+  const step = strength <= 3 ? strength - 1 : strength;
+  const percent = (step / SPECTRUM_MAX_STEP_INDEX) * 100;
 
   return `${percent}%`;
 };


### PR DESCRIPTION
# 📝 개요

후기 작성 스펙트럼 슬라이더의 변경사항을 프로필 평균 스펙트럼에 반영했습니다. 트랙 그라데이션 방향·6분할 세그먼트·마커(핸들) UI를 후기 슬라이더와 통일하고, 중앙 중립 단계를 반영해 마커 위치 계산을 7단계 슬라이더에 맞게 정렬했습니다.

## 🔗 관련 이슈

- Closes #339

## 🛠️ 변경 사항 (Checklist)

- [x] 🎨 Design: UI/UX 스타일 수정

### 주요 변경

- 트랙을 `overflow-hidden rounded` 컨테이너 + 6분할 그리드 세그먼트 구분선 구조로 재구성
- 좌/우 트랙 그라데이션 방향을 후기 스펙트럼 슬라이더와 동일하게 수정
- 마커를 `size-4` 원형 흰 배경 핸들 + 그림자로 변경
- `toMarkerLeft`: 7단계 슬라이더(중앙 중립 제외)에 맞춰 마커 위치 계산 정렬
- 클래스 결합에 `cn()` 적용

## ✅ 점검

### 1. 의도와 가독성

- [x] 의도 중심 네이밍 / 선언적 코드 / 필요한 곳에만 주석

### 2. 타입과 논리

- [x] `any` 미사용, 반환 타입 명시
- [x] `normalizeStrength`로 엣지 케이스 처리
- [x] 세그먼트 key·트랙 클래스 상수 분리

### 3. 코드 다이어트

- [x] `console.log`/미사용 import 없음
- [x] Dead code 없음
- [x] lint-staged(eslint + prettier) 통과

### 4. 지속 가능성

- [x] 로컬 UI 확인 완료